### PR TITLE
Fix README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ To run the game, ensure you have Python installed, then execute the following co
 
 ```bash
 python pRoguelike.py
+```
+
+Make sure to run the game in a terminal that supports `curses`.
+Press `Q` during play to begin the quit process.


### PR DESCRIPTION
## Summary
- close the bash code block in README.md
- mention game supports `curses` terminals and quitting with `Q`

## Testing
- `python -m py_compile pRoguelike.py`

------
https://chatgpt.com/codex/tasks/task_e_68400aa04540832bb0e53587a831acf7