### PR TITLE
Fix escape key lag

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,10 @@ Make sure to run the game in a terminal that supports `curses`.
 Use the arrow keys or the number pad for movement. Diagonal steps are mapped to
 `1`, `3`, `7`, and `9` on the number pad. Press `Q` during play to begin the
 quit process.
+
+### Note on Escape Key Responsiveness
+
+By default, `curses` waits up to a second to decide whether an `ESC` press is
+part of a special key sequence. To make exiting menus feel snappier, PRogue sets
+the delay to 25&nbsp;ms. If you wish to change this value, set the `ESCDELAY`
+environment variable before launching the game.

--- a/pRoguelike.py
+++ b/pRoguelike.py
@@ -3,6 +3,10 @@ from curses import wrapper
 import sys
 import os
 
+# Reduce the delay for detecting an isolated ESC key press. The default delay
+# can make exiting menus feel sluggish.
+os.environ.setdefault("ESCDELAY", "25")
+
 # Add the current directory to Python path to find the 'classes' package
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 
@@ -44,6 +48,8 @@ def draw(stdscr, game):
 def main(stdscr):
     # Initialize curses
     curses.start_color()
+    # Further reduce the ESC key delay inside curses itself
+    curses.set_escdelay(25)
     curses.init_pair(1, curses.COLOR_WHITE, curses.COLOR_BLACK)  # Default
     curses.init_pair(2, curses.COLOR_RED, curses.COLOR_BLACK)    # Player
     curses.init_pair(3, curses.COLOR_GREEN, curses.COLOR_BLACK)  # Monsters


### PR DESCRIPTION
## Summary
- reduce curses ESC delay to speed up menu exit
- document ESC responsiveness in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684012978b64832bbd7af1ec1eedeb26