### PR TITLE
Add walk-to-stairs command

### DIFF
--- a/classes/game.py
+++ b/classes/game.py
@@ -52,6 +52,7 @@ class Game:
         self.selected_slot = None
         self.debug_mode = False
         self.quit = False
+        self.walk_mode = False
 
     def open_character_stats_screen(self):
         self.character_stats_mode = True
@@ -352,6 +353,29 @@ class Game:
                 self.previous_level()
             else:
                 self.exit_game()
+
+    def walk_to(self, x, y):
+        """Automatically walk the player to the given coordinates using pathfinding."""
+        target = type('Target', (object,), {'x': x, 'y': y})()
+        path = self.find_path(self.player, target)
+        if not path:
+            self.messages.append("No path to destination.")
+            return
+        for step in path[1:]:
+            dx = step[0] - self.player.x
+            dy = step[1] - self.player.y
+            prev_x, prev_y = self.player.x, self.player.y
+            self.player_move_or_attack(dx, dy)
+            if (self.player.x, self.player.y) == (prev_x, prev_y):
+                break
+            if (self.player.x, self.player.y) == (x, y):
+                break
+
+    def walk_to_stairs(self, direction):
+        if direction == 'up':
+            self.walk_to(self.stairs_up_x, self.stairs_up_y)
+        elif direction == 'down':
+            self.walk_to(self.stairs_x, self.stairs_y)
     
     def exit_game(self):
         try:

--- a/classes/input_handler.py
+++ b/classes/input_handler.py
@@ -34,6 +34,23 @@ class InputHandler:
         return False  # Don't exit the game
 
     def handle_main_game_input(self, key):
+        if self.game.walk_mode:
+            if key == ord('<'):
+                self.game.walk_to_stairs('up')
+                self.game.walk_mode = False
+                return
+            elif key == ord('>'):
+                self.game.walk_to_stairs('down')
+                self.game.walk_mode = False
+                return
+            else:
+                self.game.walk_mode = False
+
+        if key == ord('w'):
+            self.game.walk_mode = True
+            self.game.messages.append("Walk to stairs: < or >")
+            return
+
         movement_keys = {
             ord('8'): (0, -1), ord('k'): (0, -1), curses.KEY_UP: (0, -1),
             ord('2'): (0, 1), ord('j'): (0, 1), curses.KEY_DOWN: (0, 1),


### PR DESCRIPTION
## Summary
- introduce `walk_mode` state and `walk_to` helper in `Game`
- add `walk_to_stairs` to move toward up or down stairs
- support new prefix command `w` in `InputHandler`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import classes.game as G
class D: 
    def getmaxyx(self): return (24,80)
    def addstr(self,*a,**k): pass
    def clear(self): pass
    def refresh(self): pass
stdscr=D(); g=G.Game(20,40,stdscr); g.enemies.clear()
print('before',g.player.x,g.player.y)
g.walk_to_stairs('down')
print('after',g.player.x,g.player.y)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68401501714c832baa6ee969a0f09c53