### PR TITLE
Fix curses endwin error on exit

### DIFF
--- a/pRoguelike.py
+++ b/pRoguelike.py
@@ -88,8 +88,8 @@ def main(stdscr):
         elif game.handle_input(key):
             break
 
-    curses.endwin()
-    print("Thanks for playing!")
+    return
 
 if __name__ == "__main__":
     wrapper(main)
+    print("Thanks for playing!")


### PR DESCRIPTION
## Summary
- prevent double cleanup when exiting the game

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840167fac30832bb541fc003c2908a9