### PR TITLE
Expand equipment tiers

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -1,342 +1,5622 @@
 {
-    "consumables": [
-      {
-        "name": "Health Potion",
-        "char": "!",
-        "effect": "heal",
-        "value": 20
-      },
-      {
-        "name": "Greater Health Potion",
-        "char": "!",
-        "effect": "heal",
-        "value": 50
-      },
-      {
-        "name": "Mana Potion",
-        "char": "!",
-        "effect": "restore_mana",
-        "value": 20
-      },
-      {
-        "name": "Greater Mana Potion",
-        "char": "!",
-        "effect": "restore_mana",
-        "value": 50
-      },
-      {
-        "name": "Strength Elixir",
-        "char": "!",
-        "effect": "boost_strength",
-        "value": 2
-      },
-      {
-        "name": "Dexterity Elixir",
-        "char": "!",
-        "effect": "boost_dexterity",
-        "value": 2
-      }
-    ],
-    "equipment": [
-      {
-        "name": "Dagger",
-        "char": "/",
-        "slot": "weapon",
-        "stat_boost": 2
-      },
-      {
-        "name": "Short Sword",
-        "char": "/",
-        "slot": "weapon",
-        "stat_boost": 4
-      },
-      {
-        "name": "Long Sword",
-        "char": "/",
-        "slot": "weapon",
-        "stat_boost": 6
-      },
-      {
-        "name": "Great Sword",
-        "char": "/",
-        "slot": "weapon",
-        "stat_boost": 8
-      },
-      {
-        "name": "Legendary Blade",
-        "char": "/",
-        "slot": "weapon",
-        "stat_boost": 10
-      },
-      {
-        "name": "Shortbow",
-        "char": "}",
-        "slot": "missile weapon",
-        "stat_boost": 3
-      },
-      {
-        "name": "Longbow",
-        "char": "}",
-        "slot": "missile weapon",
-        "stat_boost": 5
-      },
-      {
-        "name": "Crossbow",
-        "char": "}",
-        "slot": "missile weapon",
-        "stat_boost": 7
-      },
-      {
-        "name": "Leather Cap",
-        "char": "^",
-        "slot": "helmet",
-        "stat_boost": 1
-      },
-      {
-        "name": "Iron Helm",
-        "char": "^",
-        "slot": "helmet",
-        "stat_boost": 2
-      },
-      {
-        "name": "Steel Helm",
-        "char": "^",
-        "slot": "helmet",
-        "stat_boost": 3
-      },
-      {
-        "name": "Mithril Helm",
-        "char": "^",
-        "slot": "helmet",
-        "stat_boost": 4
-      },
-      {
-        "name": "Lucky Charm",
-        "char": "\"",
-        "slot": "amulet",
-        "stat_boost": 1
-      },
-      {
-        "name": "Amulet of Health",
-        "char": "\"",
-        "slot": "amulet",
-        "stat_boost": 2
-      },
-      {
-        "name": "Amulet of Protection",
-        "char": "\"",
-        "slot": "amulet",
-        "stat_boost": 3
-      },
-      {
-        "name": "Amulet of Power",
-        "char": "\"",
-        "slot": "amulet",
-        "stat_boost": 4
-      },
-      {
-        "name": "Wooden Shield",
-        "char": ")",
-        "slot": "shield",
-        "stat_boost": 1
-      },
-      {
-        "name": "Iron Shield",
-        "char": ")",
-        "slot": "shield",
-        "stat_boost": 2
-      },
-      {
-        "name": "Steel Shield",
-        "char": ")",
-        "slot": "shield",
-        "stat_boost": 3
-      },
-      {
-        "name": "Tower Shield",
-        "char": ")",
-        "slot": "shield",
-        "stat_boost": 4
-      },
-      {
-        "name": "Leather Armor",
-        "char": "[",
-        "slot": "armor",
-        "stat_boost": 1
-      },
-      {
-        "name": "Studded Leather",
-        "char": "[",
-        "slot": "armor",
-        "stat_boost": 2
-      },
-      {
-        "name": "Chain Mail",
-        "char": "[",
-        "slot": "armor",
-        "stat_boost": 3
-      },
-      {
-        "name": "Plate Armor",
-        "char": "[",
-        "slot": "armor",
-        "stat_boost": 5
-      },
-      {
-        "name": "Mithril Armor",
-        "char": "[",
-        "slot": "armor",
-        "stat_boost": 7
-      },
-      {
-        "name": "Cloth Cloak",
-        "char": "B",
-        "slot": "cloak",
-        "stat_boost": 1
-      },
-      {
-        "name": "Elven Cloak",
-        "char": "B",
-        "slot": "cloak",
-        "stat_boost": 2
-      },
-      {
-        "name": "Cloak of Protection",
-        "char": "B",
-        "slot": "cloak",
-        "stat_boost": 3
-      },
-      {
-        "name": "Cloak of Invisibility",
-        "char": "B",
-        "slot": "cloak",
-        "stat_boost": 4
-      },
-      {
-        "name": "Leather Belt",
-        "char": ":",
-        "slot": "girdle",
-        "stat_boost": 1
-      },
-      {
-        "name": "Strength Belt",
-        "char": ":",
-        "slot": "girdle",
-        "stat_boost": 2
-      },
-      {
-        "name": "Giant's Belt",
-        "char": ":",
-        "slot": "girdle",
-        "stat_boost": 3
-      },
-      {
-        "name": "Leather Gloves",
-        "char": "]",
-        "slot": "gauntlets",
-        "stat_boost": 1
-      },
-      {
-        "name": "Iron Gauntlets",
-        "char": "]",
-        "slot": "gauntlets",
-        "stat_boost": 2
-      },
-      {
-        "name": "Gauntlets of Strength",
-        "char": "]",
-        "slot": "gauntlets",
-        "stat_boost": 3
-      },
-      {
-        "name": "Mithril Gauntlets",
-        "char": "]",
-        "slot": "gauntlets",
-        "stat_boost": 4
-      },
-      {
-        "name": "Leather Boots",
-        "char": "(",
-        "slot": "boots",
-        "stat_boost": 1
-      },
-      {
-        "name": "Iron Boots",
-        "char": "(",
-        "slot": "boots",
-        "stat_boost": 2
-      },
-      {
-        "name": "Boots of Speed",
-        "char": "(",
-        "slot": "boots",
-        "stat_boost": 3
-      },
-      {
-        "name": "Winged Boots",
-        "char": "(",
-        "slot": "boots",
-        "stat_boost": 4
-      },
-      {
-        "name": "Ring of Protection",
-        "char": "=",
-        "slot": "ring (right)",
-        "stat_boost": 1
-      },
-      {
-        "name": "Ring of Strength",
-        "char": "=",
-        "slot": "ring (left)",
-        "stat_boost": 1
-      },
-      {
-        "name": "Ring of Dexterity",
-        "char": "=",
-        "slot": "ring (right)",
-        "stat_boost": 2
-      },
-      {
-        "name": "Ring of Constitution",
-        "char": "=",
-        "slot": "ring (left)",
-        "stat_boost": 2
-      },
-      {
-        "name": "Ring of Power",
-        "char": "=",
-        "slot": "ring (right)",
-        "stat_boost": 3
-      },
-      {
-        "name": "Ring of the Magi",
-        "char": "=",
-        "slot": "ring (left)",
-        "stat_boost": 3
-      },
-      {
-        "name": "Leather Bracers",
-        "char": "|",
-        "slot": "bracers",
-        "stat_boost": 1
-      },
-      {
-        "name": "Iron Bracers",
-        "char": "|",
-        "slot": "bracers",
-        "stat_boost": 2
-      },
-      {
-        "name": "Bracers of Archery",
-        "char": "|",
-        "slot": "bracers",
-        "stat_boost": 3
-      },
-      {
-        "name": "Bracers of Defense",
-        "char": "|",
-        "slot": "bracers",
-        "stat_boost": 4
-      }
-    ]
-  }
+  "consumables": [
+    {
+      "name": "Health Potion",
+      "char": "!",
+      "effect": "heal",
+      "value": 20
+    },
+    {
+      "name": "Greater Health Potion",
+      "char": "!",
+      "effect": "heal",
+      "value": 50
+    },
+    {
+      "name": "Mana Potion",
+      "char": "!",
+      "effect": "restore_mana",
+      "value": 20
+    },
+    {
+      "name": "Greater Mana Potion",
+      "char": "!",
+      "effect": "restore_mana",
+      "value": 50
+    },
+    {
+      "name": "Strength Elixir",
+      "char": "!",
+      "effect": "boost_strength",
+      "value": 2
+    },
+    {
+      "name": "Dexterity Elixir",
+      "char": "!",
+      "effect": "boost_dexterity",
+      "value": 2
+    }
+  ],
+  "equipment": [
+    {
+      "name": "Bronze Arming Sword",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Iron Arming Sword",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Steel Arming Sword",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Fine Steel Arming Sword",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Mithril Arming Sword",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Adamantine Arming Sword",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Obsidian Arming Sword",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Dragonbone Arming Sword",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Ethereal Arming Sword",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Legendary Arming Sword",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Bronze Bastard Sword",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Iron Bastard Sword",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Steel Bastard Sword",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Fine Steel Bastard Sword",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Mithril Bastard Sword",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Adamantine Bastard Sword",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Obsidian Bastard Sword",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Dragonbone Bastard Sword",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Ethereal Bastard Sword",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Legendary Bastard Sword",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Bronze Claymore",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Iron Claymore",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Steel Claymore",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Fine Steel Claymore",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Mithril Claymore",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Adamantine Claymore",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Obsidian Claymore",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Dragonbone Claymore",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Ethereal Claymore",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Legendary Claymore",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Bronze Flamberge",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Iron Flamberge",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Steel Flamberge",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Fine Steel Flamberge",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Mithril Flamberge",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Adamantine Flamberge",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Obsidian Flamberge",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Dragonbone Flamberge",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Ethereal Flamberge",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Legendary Flamberge",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Bronze Katana",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Iron Katana",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Steel Katana",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Fine Steel Katana",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Mithril Katana",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Adamantine Katana",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Obsidian Katana",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Dragonbone Katana",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Ethereal Katana",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Legendary Katana",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Bronze Gladius",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Iron Gladius",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Steel Gladius",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Fine Steel Gladius",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Mithril Gladius",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Adamantine Gladius",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Obsidian Gladius",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Dragonbone Gladius",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Ethereal Gladius",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Legendary Gladius",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Bronze Falchion",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Iron Falchion",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Steel Falchion",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Fine Steel Falchion",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Mithril Falchion",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Adamantine Falchion",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Obsidian Falchion",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Dragonbone Falchion",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Ethereal Falchion",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Legendary Falchion",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Bronze Cutlass",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Iron Cutlass",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Steel Cutlass",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Fine Steel Cutlass",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Mithril Cutlass",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Adamantine Cutlass",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Obsidian Cutlass",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Dragonbone Cutlass",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Ethereal Cutlass",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Legendary Cutlass",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Bronze Sabre",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Iron Sabre",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Steel Sabre",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Fine Steel Sabre",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Mithril Sabre",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Adamantine Sabre",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Obsidian Sabre",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Dragonbone Sabre",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Ethereal Sabre",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Legendary Sabre",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Bronze Rapier",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Iron Rapier",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Steel Rapier",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Fine Steel Rapier",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Mithril Rapier",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Adamantine Rapier",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Obsidian Rapier",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Dragonbone Rapier",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Ethereal Rapier",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Legendary Rapier",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Bronze Stiletto",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 3
+    },
+    {
+      "name": "Iron Stiletto",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Steel Stiletto",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Fine Steel Stiletto",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Mithril Stiletto",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Adamantine Stiletto",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Obsidian Stiletto",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Dragonbone Stiletto",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Ethereal Stiletto",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Legendary Stiletto",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Bronze Dirk",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 3
+    },
+    {
+      "name": "Iron Dirk",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Steel Dirk",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Fine Steel Dirk",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Mithril Dirk",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Adamantine Dirk",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Obsidian Dirk",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Dragonbone Dirk",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Ethereal Dirk",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Legendary Dirk",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Bronze Kris",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 3
+    },
+    {
+      "name": "Iron Kris",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Steel Kris",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Fine Steel Kris",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Mithril Kris",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Adamantine Kris",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Obsidian Kris",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Dragonbone Kris",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Ethereal Kris",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Legendary Kris",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Bronze Rondel",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 3
+    },
+    {
+      "name": "Iron Rondel",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Steel Rondel",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Fine Steel Rondel",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Mithril Rondel",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Adamantine Rondel",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Obsidian Rondel",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Dragonbone Rondel",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Ethereal Rondel",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Legendary Rondel",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Bronze Cinquedea",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 3
+    },
+    {
+      "name": "Iron Cinquedea",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Steel Cinquedea",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Fine Steel Cinquedea",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Mithril Cinquedea",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Adamantine Cinquedea",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Obsidian Cinquedea",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Dragonbone Cinquedea",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Ethereal Cinquedea",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Legendary Cinquedea",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Bronze Club",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Iron Club",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Steel Club",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Fine Steel Club",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Mithril Club",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Adamantine Club",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Obsidian Club",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Dragonbone Club",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Ethereal Club",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Legendary Club",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Bronze Morning Star",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Iron Morning Star",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Steel Morning Star",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Fine Steel Morning Star",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Mithril Morning Star",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Adamantine Morning Star",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Obsidian Morning Star",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Dragonbone Morning Star",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Ethereal Morning Star",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Legendary Morning Star",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Bronze Flanged Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Iron Flanged Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Steel Flanged Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Fine Steel Flanged Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Mithril Flanged Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Adamantine Flanged Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Obsidian Flanged Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Dragonbone Flanged Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Ethereal Flanged Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Legendary Flanged Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Bronze Holy Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Iron Holy Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Steel Holy Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Fine Steel Holy Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Mithril Holy Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Adamantine Holy Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Obsidian Holy Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Dragonbone Holy Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Ethereal Holy Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Legendary Holy Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Bronze War Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Iron War Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Steel War Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Fine Steel War Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Mithril War Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Adamantine War Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Obsidian War Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Dragonbone War Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Ethereal War Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Legendary War Mace",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Bronze War Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Iron War Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Steel War Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Fine Steel War Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Mithril War Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Adamantine War Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Obsidian War Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Dragonbone War Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Ethereal War Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Legendary War Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 15
+    },
+    {
+      "name": "Bronze Maul",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Iron Maul",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Steel Maul",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Fine Steel Maul",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Mithril Maul",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Adamantine Maul",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Obsidian Maul",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Dragonbone Maul",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Ethereal Maul",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Legendary Maul",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 15
+    },
+    {
+      "name": "Bronze Sledge Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Iron Sledge Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Steel Sledge Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Fine Steel Sledge Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Mithril Sledge Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Adamantine Sledge Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Obsidian Sledge Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Dragonbone Sledge Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Ethereal Sledge Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Legendary Sledge Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 15
+    },
+    {
+      "name": "Bronze Lucerne Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Iron Lucerne Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Steel Lucerne Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Fine Steel Lucerne Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Mithril Lucerne Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Adamantine Lucerne Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Obsidian Lucerne Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Dragonbone Lucerne Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Ethereal Lucerne Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Legendary Lucerne Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 15
+    },
+    {
+      "name": "Bronze Forge Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Iron Forge Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Steel Forge Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Fine Steel Forge Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Mithril Forge Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Adamantine Forge Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Obsidian Forge Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Dragonbone Forge Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Ethereal Forge Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Legendary Forge Hammer",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 15
+    },
+    {
+      "name": "Bronze Hand Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Iron Hand Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Steel Hand Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Fine Steel Hand Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Mithril Hand Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Adamantine Hand Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Obsidian Hand Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Dragonbone Hand Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Ethereal Hand Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Legendary Hand Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Bronze Battle Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Iron Battle Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Steel Battle Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Fine Steel Battle Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Mithril Battle Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Adamantine Battle Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Obsidian Battle Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Dragonbone Battle Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Ethereal Battle Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Legendary Battle Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Bronze Great Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Iron Great Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Steel Great Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Fine Steel Great Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Mithril Great Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Adamantine Great Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Obsidian Great Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Dragonbone Great Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Ethereal Great Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Legendary Great Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Bronze Double Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Iron Double Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Steel Double Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Fine Steel Double Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Mithril Double Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Adamantine Double Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Obsidian Double Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Dragonbone Double Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Ethereal Double Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Legendary Double Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Bronze Throwing Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Iron Throwing Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Steel Throwing Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Fine Steel Throwing Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Mithril Throwing Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Adamantine Throwing Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Obsidian Throwing Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Dragonbone Throwing Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Ethereal Throwing Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Legendary Throwing Axe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Bronze Short Spear",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Iron Short Spear",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Steel Short Spear",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Fine Steel Short Spear",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Mithril Short Spear",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Adamantine Short Spear",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Obsidian Short Spear",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Dragonbone Short Spear",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Ethereal Short Spear",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Legendary Short Spear",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Bronze Long Spear",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Iron Long Spear",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Steel Long Spear",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Fine Steel Long Spear",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Mithril Long Spear",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Adamantine Long Spear",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Obsidian Long Spear",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Dragonbone Long Spear",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Ethereal Long Spear",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Legendary Long Spear",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Bronze Javelin",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Iron Javelin",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Steel Javelin",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Fine Steel Javelin",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Mithril Javelin",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Adamantine Javelin",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Obsidian Javelin",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Dragonbone Javelin",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Ethereal Javelin",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Legendary Javelin",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Bronze Pike",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Iron Pike",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Steel Pike",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Fine Steel Pike",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Mithril Pike",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Adamantine Pike",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Obsidian Pike",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Dragonbone Pike",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Ethereal Pike",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Legendary Pike",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Bronze Trident",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Iron Trident",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Steel Trident",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Fine Steel Trident",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Mithril Trident",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Adamantine Trident",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Obsidian Trident",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Dragonbone Trident",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Ethereal Trident",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Legendary Trident",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Bronze Halberd",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Iron Halberd",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Steel Halberd",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Fine Steel Halberd",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Mithril Halberd",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Adamantine Halberd",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Obsidian Halberd",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Dragonbone Halberd",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Ethereal Halberd",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Legendary Halberd",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 15
+    },
+    {
+      "name": "Bronze Glaive",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Iron Glaive",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Steel Glaive",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Fine Steel Glaive",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Mithril Glaive",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Adamantine Glaive",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Obsidian Glaive",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Dragonbone Glaive",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Ethereal Glaive",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Legendary Glaive",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 15
+    },
+    {
+      "name": "Bronze Naginata",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Iron Naginata",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Steel Naginata",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Fine Steel Naginata",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Mithril Naginata",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Adamantine Naginata",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Obsidian Naginata",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Dragonbone Naginata",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Ethereal Naginata",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Legendary Naginata",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 15
+    },
+    {
+      "name": "Bronze Bardiche",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Iron Bardiche",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Steel Bardiche",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Fine Steel Bardiche",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Mithril Bardiche",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Adamantine Bardiche",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Obsidian Bardiche",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Dragonbone Bardiche",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Ethereal Bardiche",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Legendary Bardiche",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 15
+    },
+    {
+      "name": "Bronze Scythe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Iron Scythe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Steel Scythe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Fine Steel Scythe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Mithril Scythe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Adamantine Scythe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Obsidian Scythe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Dragonbone Scythe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Ethereal Scythe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Legendary Scythe",
+      "char": "/",
+      "slot": "weapon",
+      "stat_boost": 15
+    },
+    {
+      "name": "Bronze Light Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Iron Light Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Steel Light Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Fine Steel Light Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Mithril Light Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Adamantine Light Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Obsidian Light Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Dragonbone Light Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Ethereal Light Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Legendary Light Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 15
+    },
+    {
+      "name": "Bronze Heavy Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Iron Heavy Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Steel Heavy Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Fine Steel Heavy Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Mithril Heavy Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Adamantine Heavy Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Obsidian Heavy Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Dragonbone Heavy Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Ethereal Heavy Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Legendary Heavy Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 15
+    },
+    {
+      "name": "Bronze Repeating Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Iron Repeating Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Steel Repeating Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Fine Steel Repeating Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Mithril Repeating Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Adamantine Repeating Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Obsidian Repeating Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Dragonbone Repeating Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Ethereal Repeating Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Legendary Repeating Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 15
+    },
+    {
+      "name": "Bronze Siege Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Iron Siege Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Steel Siege Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Fine Steel Siege Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Mithril Siege Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Adamantine Siege Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Obsidian Siege Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Dragonbone Siege Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Ethereal Siege Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Legendary Siege Crossbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 15
+    },
+    {
+      "name": "Bronze Arbalest",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Iron Arbalest",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Steel Arbalest",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Fine Steel Arbalest",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Mithril Arbalest",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Adamantine Arbalest",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Obsidian Arbalest",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Dragonbone Arbalest",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Ethereal Arbalest",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Legendary Arbalest",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 15
+    },
+    {
+      "name": "Bronze Simple Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Iron Simple Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Steel Simple Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Fine Steel Simple Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Mithril Simple Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Adamantine Simple Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Obsidian Simple Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Dragonbone Simple Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Ethereal Simple Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Legendary Simple Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Bronze Composite Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Iron Composite Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Steel Composite Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Fine Steel Composite Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Mithril Composite Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Adamantine Composite Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Obsidian Composite Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Dragonbone Composite Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Ethereal Composite Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Legendary Composite Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Bronze Recurve Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Iron Recurve Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Steel Recurve Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Fine Steel Recurve Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Mithril Recurve Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Adamantine Recurve Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Obsidian Recurve Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Dragonbone Recurve Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Ethereal Recurve Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Legendary Recurve Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Bronze Greatbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Iron Greatbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Steel Greatbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Fine Steel Greatbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Mithril Greatbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Adamantine Greatbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Obsidian Greatbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Dragonbone Greatbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Ethereal Greatbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Legendary Greatbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Bronze Elven Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Iron Elven Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Steel Elven Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Fine Steel Elven Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Mithril Elven Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Adamantine Elven Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Obsidian Elven Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Dragonbone Elven Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Ethereal Elven Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Legendary Elven Longbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 14
+    },
+    {
+      "name": "Bronze Simple Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Iron Simple Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Steel Simple Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Fine Steel Simple Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Mithril Simple Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Adamantine Simple Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Obsidian Simple Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Dragonbone Simple Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Ethereal Simple Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Legendary Simple Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Bronze Composite Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Iron Composite Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Steel Composite Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Fine Steel Composite Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Mithril Composite Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Adamantine Composite Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Obsidian Composite Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Dragonbone Composite Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Ethereal Composite Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Legendary Composite Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Bronze Recurve Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Iron Recurve Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Steel Recurve Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Fine Steel Recurve Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Mithril Recurve Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Adamantine Recurve Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Obsidian Recurve Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Dragonbone Recurve Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Ethereal Recurve Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Legendary Recurve Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Bronze Hunting Bow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Iron Hunting Bow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Steel Hunting Bow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Fine Steel Hunting Bow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Mithril Hunting Bow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Adamantine Hunting Bow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Obsidian Hunting Bow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Dragonbone Hunting Bow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Ethereal Hunting Bow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Legendary Hunting Bow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Bronze Elven Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Iron Elven Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Steel Elven Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Fine Steel Elven Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Mithril Elven Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Adamantine Elven Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Obsidian Elven Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Dragonbone Elven Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Ethereal Elven Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Legendary Elven Shortbow",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 13
+    },
+    {
+      "name": "Bronze Simple Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 3
+    },
+    {
+      "name": "Iron Simple Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Steel Simple Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Fine Steel Simple Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Mithril Simple Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Adamantine Simple Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Obsidian Simple Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Dragonbone Simple Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Ethereal Simple Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Legendary Simple Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Bronze Staff Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 3
+    },
+    {
+      "name": "Iron Staff Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Steel Staff Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Fine Steel Staff Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Mithril Staff Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Adamantine Staff Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Obsidian Staff Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Dragonbone Staff Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Ethereal Staff Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Legendary Staff Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Bronze Heavy Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 3
+    },
+    {
+      "name": "Iron Heavy Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Steel Heavy Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Fine Steel Heavy Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Mithril Heavy Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Adamantine Heavy Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Obsidian Heavy Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Dragonbone Heavy Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Ethereal Heavy Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Legendary Heavy Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Bronze Whip Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 3
+    },
+    {
+      "name": "Iron Whip Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Steel Whip Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Fine Steel Whip Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Mithril Whip Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Adamantine Whip Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Obsidian Whip Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Dragonbone Whip Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Ethereal Whip Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Legendary Whip Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Bronze Precision Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 3
+    },
+    {
+      "name": "Iron Precision Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 4
+    },
+    {
+      "name": "Steel Precision Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 5
+    },
+    {
+      "name": "Fine Steel Precision Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 6
+    },
+    {
+      "name": "Mithril Precision Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 7
+    },
+    {
+      "name": "Adamantine Precision Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 8
+    },
+    {
+      "name": "Obsidian Precision Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 9
+    },
+    {
+      "name": "Dragonbone Precision Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 10
+    },
+    {
+      "name": "Ethereal Precision Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 11
+    },
+    {
+      "name": "Legendary Precision Sling",
+      "char": "}",
+      "slot": "missile weapon",
+      "stat_boost": 12
+    },
+    {
+      "name": "Bronze Cap",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Cap",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Cap",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Cap",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Cap",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Cap",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Cap",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Cap",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Cap",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Cap",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Helm",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Helm",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Helm",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Helm",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Helm",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Helm",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Helm",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Helm",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Helm",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Helm",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Great Helm",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Great Helm",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Great Helm",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Great Helm",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Great Helm",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Great Helm",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Great Helm",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Great Helm",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Great Helm",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Great Helm",
+      "char": "^",
+      "slot": "helmet",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Pendant",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Pendant",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Pendant",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Pendant",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Pendant",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Pendant",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Pendant",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Pendant",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Pendant",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Pendant",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Amulet",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Amulet",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Amulet",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Amulet",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Amulet",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Amulet",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Amulet",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Amulet",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Amulet",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Amulet",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Talisman",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Talisman",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Talisman",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Talisman",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Talisman",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Talisman",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Talisman",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Talisman",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Talisman",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Talisman",
+      "char": "\"",
+      "slot": "amulet",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Buckler",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Buckler",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Buckler",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Buckler",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Buckler",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Buckler",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Buckler",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Buckler",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Buckler",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Buckler",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Kite Shield",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Kite Shield",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Kite Shield",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Kite Shield",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Kite Shield",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Kite Shield",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Kite Shield",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Kite Shield",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Kite Shield",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Kite Shield",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Tower Shield",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Tower Shield",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Tower Shield",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Tower Shield",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Tower Shield",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Tower Shield",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Tower Shield",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Tower Shield",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Tower Shield",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Tower Shield",
+      "char": ")",
+      "slot": "shield",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Robe",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 2
+    },
+    {
+      "name": "Iron Robe",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 3
+    },
+    {
+      "name": "Steel Robe",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 4
+    },
+    {
+      "name": "Fine Steel Robe",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 5
+    },
+    {
+      "name": "Mithril Robe",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 6
+    },
+    {
+      "name": "Adamantine Robe",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 7
+    },
+    {
+      "name": "Obsidian Robe",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 8
+    },
+    {
+      "name": "Dragonbone Robe",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 9
+    },
+    {
+      "name": "Ethereal Robe",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 10
+    },
+    {
+      "name": "Legendary Robe",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 11
+    },
+    {
+      "name": "Bronze Chain Mail",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 2
+    },
+    {
+      "name": "Iron Chain Mail",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 3
+    },
+    {
+      "name": "Steel Chain Mail",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 4
+    },
+    {
+      "name": "Fine Steel Chain Mail",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 5
+    },
+    {
+      "name": "Mithril Chain Mail",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 6
+    },
+    {
+      "name": "Adamantine Chain Mail",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 7
+    },
+    {
+      "name": "Obsidian Chain Mail",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 8
+    },
+    {
+      "name": "Dragonbone Chain Mail",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 9
+    },
+    {
+      "name": "Ethereal Chain Mail",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 10
+    },
+    {
+      "name": "Legendary Chain Mail",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 11
+    },
+    {
+      "name": "Bronze Plate Armor",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 2
+    },
+    {
+      "name": "Iron Plate Armor",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 3
+    },
+    {
+      "name": "Steel Plate Armor",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 4
+    },
+    {
+      "name": "Fine Steel Plate Armor",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 5
+    },
+    {
+      "name": "Mithril Plate Armor",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 6
+    },
+    {
+      "name": "Adamantine Plate Armor",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 7
+    },
+    {
+      "name": "Obsidian Plate Armor",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 8
+    },
+    {
+      "name": "Dragonbone Plate Armor",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 9
+    },
+    {
+      "name": "Ethereal Plate Armor",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 10
+    },
+    {
+      "name": "Legendary Plate Armor",
+      "char": "[",
+      "slot": "armor",
+      "stat_boost": 11
+    },
+    {
+      "name": "Bronze Cloak",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Cloak",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Cloak",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Cloak",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Cloak",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Cloak",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Cloak",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Cloak",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Cloak",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Cloak",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Cape",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Cape",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Cape",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Cape",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Cape",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Cape",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Cape",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Cape",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Cape",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Cape",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Mantle",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Mantle",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Mantle",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Mantle",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Mantle",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Mantle",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Mantle",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Mantle",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Mantle",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Mantle",
+      "char": "B",
+      "slot": "cloak",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Belt",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Belt",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Belt",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Belt",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Belt",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Belt",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Belt",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Belt",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Belt",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Belt",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Chain Belt",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Chain Belt",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Chain Belt",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Chain Belt",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Chain Belt",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Chain Belt",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Chain Belt",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Chain Belt",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Chain Belt",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Chain Belt",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Girdle",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Girdle",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Girdle",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Girdle",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Girdle",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Girdle",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Girdle",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Girdle",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Girdle",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Girdle",
+      "char": ":",
+      "slot": "girdle",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Gloves",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Gloves",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Gloves",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Gloves",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Gloves",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Gloves",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Gloves",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Gloves",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Gloves",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Gloves",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Gauntlets",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Gauntlets",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Gauntlets",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Gauntlets",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Gauntlets",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Gauntlets",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Gauntlets",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Gauntlets",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Gauntlets",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Gauntlets",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Vambraces",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Vambraces",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Vambraces",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Vambraces",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Vambraces",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Vambraces",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Vambraces",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Vambraces",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Vambraces",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Vambraces",
+      "char": "]",
+      "slot": "gauntlets",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Sandals",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Sandals",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Sandals",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Sandals",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Sandals",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Sandals",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Sandals",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Sandals",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Sandals",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Sandals",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Boots",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Boots",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Boots",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Boots",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Boots",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Boots",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Boots",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Boots",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Boots",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Boots",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Greaves",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Greaves",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Greaves",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Greaves",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Greaves",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Greaves",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Greaves",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Greaves",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Greaves",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Greaves",
+      "char": "(",
+      "slot": "boots",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Wristguards",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Wristguards",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Wristguards",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Wristguards",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Wristguards",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Wristguards",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Wristguards",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Wristguards",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Wristguards",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Wristguards",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Bracers",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Bracers",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Bracers",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Bracers",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Bracers",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Bracers",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Bracers",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Bracers",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Bracers",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Bracers",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Armguards",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Armguards",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Armguards",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Armguards",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Armguards",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Armguards",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Armguards",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Armguards",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Armguards",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Armguards",
+      "char": "|",
+      "slot": "bracers",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Ring",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Ring",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Ring",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Ring",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Ring",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Ring",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Ring",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Ring",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Ring",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Ring",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Band",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Band",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Band",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Band",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Band",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Band",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Band",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Band",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Band",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Band",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Signet",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Signet",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Signet",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Signet",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Signet",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Signet",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Signet",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Signet",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Signet",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Signet",
+      "char": "=",
+      "slot": "ring (right)",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Ring",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Ring",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Ring",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Ring",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Ring",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Ring",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Ring",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Ring",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Ring",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Ring",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Band",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Band",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Band",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Band",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Band",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Band",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Band",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Band",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Band",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Band",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 10
+    },
+    {
+      "name": "Bronze Signet",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 1
+    },
+    {
+      "name": "Iron Signet",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 2
+    },
+    {
+      "name": "Steel Signet",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 3
+    },
+    {
+      "name": "Fine Steel Signet",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 4
+    },
+    {
+      "name": "Mithril Signet",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 5
+    },
+    {
+      "name": "Adamantine Signet",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 6
+    },
+    {
+      "name": "Obsidian Signet",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 7
+    },
+    {
+      "name": "Dragonbone Signet",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 8
+    },
+    {
+      "name": "Ethereal Signet",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 9
+    },
+    {
+      "name": "Legendary Signet",
+      "char": "=",
+      "slot": "ring (left)",
+      "stat_boost": 10
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- expand equipment list with 10 material tiers for every weapon and armor item
- ensure a variety of weapon categories including long/short swords, daggers, maces, hammers, axes, spears, polearms, bows, crossbows and slings
- provide three or more base armor types for each body part

## Testing
- `python3 -m json.tool data/items.json >/tmp/valid_check && echo OK`
- `python3 - <<'PY'
from classes.item_loader import load_items
c,e,a=load_items()
print(len(c), len(e))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68401fb66514832badd21f6f68b28b42