### PR TITLE
Fix player death when HP negative

### DIFF
--- a/classes/game.py
+++ b/classes/game.py
@@ -105,7 +105,7 @@ class Game:
                     self.items.append(dropped_item)
                     self.messages.append(f"{defender.name} dropped a {dropped_item.name}!")
             elif defender == self.player:
-                self.messages.append("Game Over!")
+                self.handle_player_death()
 
         return defeated
 
@@ -468,6 +468,12 @@ class Game:
         # This method should be implemented to wait for a key press
         # For now, we'll just pass
         pass
+
+    def handle_player_death(self):
+        """Handle player death by setting the quit flag and truncating health."""
+        self.player.health = max(0, self.player.health)
+        self.messages.append("Game Over!")
+        self.quit = True
     
     def previous_level(self):
         self.dungeon_level -= 1

--- a/pRoguelike.py
+++ b/pRoguelike.py
@@ -75,6 +75,9 @@ def main(stdscr):
         else:
             game.renderer.draw(stdscr)
 
+        if game.quit:
+            break
+
         key = stdscr.getch()
         if game.debug_mode and key == 27:  # ESC key
             game.debug_mode = False
@@ -86,6 +89,9 @@ def main(stdscr):
             elif game.handle_input(key):
                 break
         elif game.handle_input(key):
+            break
+
+        if game.quit:
             break
 
     return


### PR DESCRIPTION
## Summary
- properly end game when player's HP reaches 0 or below
- break main loop when game is flagged to quit

## Testing
- `python -m py_compile classes/game.py pRoguelike.py`
- Manual test script to ensure combat sets `quit` flag

------
https://chatgpt.com/codex/tasks/task_e_68402330201c832b9fd0b5fd55c8a6c3