### PR TITLE
Add cheat menu commands

### DIFF
--- a/classes/game.py
+++ b/classes/game.py
@@ -90,6 +90,44 @@ class Game:
         else:
             return Item(item_template.name, item_template.char, item_template.effect)
 
+    def create_specific_item(self, category):
+        if category == 'potion':
+            template = random.choice(all_consumables)
+        elif category == 'weapon':
+            pool = [e for e in all_equipment if e.slot in ['weapon', 'missile weapon']]
+            template = random.choice(pool)
+        elif category == 'armor':
+            pool = [e for e in all_equipment if e.slot == 'armor']
+            template = random.choice(pool)
+        elif category == 'accessory':
+            pool = [e for e in all_equipment if e.slot not in ['weapon', 'missile weapon', 'armor']]
+            template = random.choice(pool)
+        else:
+            template = random.choice(all_items)
+
+        if isinstance(template, Equipment):
+            return Equipment(
+                template.name,
+                template.char,
+                template.slot,
+                template.stat_boost,
+                accuracy_bonus=template.accuracy_bonus,
+            )
+        else:
+            return Item(template.name, template.char, template.effect)
+
+    def map_current_level(self):
+        for y in range(self.height):
+            for x in range(self.width):
+                self.explored[y][x] = True
+        self.messages.append("The layout of the area reveals itself.")
+
+    def level_up_player(self):
+        previous_level = self.player.level
+        self.player.gain_xp(self.player.xp_to_next_level)
+        if self.player.level > previous_level:
+            self.messages.append(f"You reach level {self.player.level}!")
+
     def combat(self, attacker, defender):
         defeated = self.combat_system.combat(attacker, defender, self.messages)
 

--- a/classes/input_handler.py
+++ b/classes/input_handler.py
@@ -178,10 +178,38 @@ class InputHandler:
             self.game.use_backpack_item(chr(key))
 
     def handle_debug_input(self, key):
+        # If the menu isn't open yet, hitting '!' will open it
+        if not self.game.debug_mode and key == ord('!'):
+            self.game.debug_mode = True
+            return
+
         if key == 27:  # ESC key
             self.game.debug_mode = False
             return
 
-        item = self.game.create_random_item()
-        self.game.player.add_item(item)
-        self.game.messages.append(f"Spawned {item.name} in your inventory.")
+        if key == ord('a'):
+            item = self.game.create_specific_item('weapon')
+            self.game.player.add_item(item)
+            self.game.messages.append(f"Created {item.name} in your inventory.")
+            self.game.debug_mode = False
+        elif key == ord('b'):
+            item = self.game.create_specific_item('armor')
+            self.game.player.add_item(item)
+            self.game.messages.append(f"Created {item.name} in your inventory.")
+            self.game.debug_mode = False
+        elif key == ord('c'):
+            item = self.game.create_specific_item('accessory')
+            self.game.player.add_item(item)
+            self.game.messages.append(f"Created {item.name} in your inventory.")
+            self.game.debug_mode = False
+        elif key == ord('d'):
+            item = self.game.create_specific_item('potion')
+            self.game.player.add_item(item)
+            self.game.messages.append(f"Created {item.name} in your inventory.")
+            self.game.debug_mode = False
+        elif key == ord('e'):
+            self.game.map_current_level()
+            self.game.debug_mode = False
+        elif key == ord('f'):
+            self.game.level_up_player()
+            self.game.debug_mode = False

--- a/classes/renderer.py
+++ b/classes/renderer.py
@@ -254,10 +254,13 @@ class Renderer:
         height, width = stdscr.getmaxyx()
 
         menu_text = [
-            "Debug Menu (press escape to exit):",
-            "i) Spawn an item",
-            "x) Gain 100 XP",
-            "m) Gain 100 gold"
+            "Cheat Menu (press escape to exit):",
+            "a) Create weapon",
+            "b) Create armor",
+            "c) Create accessory",
+            "d) Create potion",
+            "e) Map level",
+            "f) Level up",
         ]
 
         for i, line in enumerate(menu_text):


### PR DESCRIPTION
## Summary
- implement cheat menu triggered by `!`
- allow creating weapons, armor, accessories and potions
- add actions to map the level or level up
- show new options in debug menu renderer

## Testing
- `python -m py_compile pRoguelike.py classes/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6840257d0164832b897a9e23f705bebc