### PR TITLE
Add character sheet and remove unused keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ control to you.
 While in the dungeon, press `i` to open your inventory. Press the letter
 corresponding to an equipment item to wear or wield it. Any item already in that
 slot will be returned to your pack automatically.
+
+Press `@` to view your character sheet, which lists your statistics and all
+currently equipped items.
 =======
 
 ### Note on Escape Key Responsiveness

--- a/classes/game.py
+++ b/classes/game.py
@@ -161,9 +161,6 @@ class Game:
         elif key == ord('i'):
             self.inventory_mode = True
             self.inventory_page = 0
-        elif key == ord('I'):
-            self.backpack_mode = True
-            self.backpack_page = 0
         elif key == ord('d'):
             self.drop_mode = True
             self.backpack_page = 0

--- a/classes/input_handler.py
+++ b/classes/input_handler.py
@@ -22,9 +22,6 @@ class InputHandler:
         elif key == ord('i'):
             self.game.inventory_mode = True
             self.game.inventory_page = 0
-        elif key == ord('I'):
-            self.game.backpack_mode = True
-            self.game.backpack_page = 0
         elif key == ord('@'):
             self.game.open_character_stats_screen()
         elif key == ord('Q'):
@@ -88,8 +85,6 @@ class InputHandler:
 
         if key == ord('i'):
             self.game.open_inventory()
-        elif key == ord('c'):
-            self.game.open_character_screen()
         elif key == ord(','):
             self.game.pickup_item()
         elif key == ord('>'):

--- a/classes/renderer.py
+++ b/classes/renderer.py
@@ -235,17 +235,26 @@ class Renderer:
             f"Age: {self.game.player.age} years",
         ]
 
-        # Draw attributes
-        for i, line in enumerate(attributes, start=2):
-            if i >= height:
-                break
-            stdscr.addstr(i, 0, line[:width-1])
+        # Equipment Data
+        equipment_lines = [
+            f"{slot['name'].title()}: {slot['item'].name if slot['item'] else 'Empty'}"
+            for slot in self.game.player.equipment.values()
+        ]
 
-        # Draw miscellaneous data
-        for i, line in enumerate(misc_data, start=2):
+        left_lines = attributes + [""] + misc_data
+        left_width = width // 2 - 2
+
+        for i, line in enumerate(left_lines, start=2):
             if i >= height:
                 break
-            stdscr.addstr(i, width // 2, line[:width-1])
+            stdscr.addstr(i, 0, line[:left_width])
+
+        right_start = 1
+        stdscr.addstr(right_start, width // 2, "Equipment:")
+        for i, line in enumerate(equipment_lines, start=right_start + 1):
+            if i >= height:
+                break
+            stdscr.addstr(i, width // 2, line[:width // 2 - 1])
 
         stdscr.refresh()
 


### PR DESCRIPTION
## Summary
- drop `c` and `I` commands
- show equipment on the `@` character sheet
- mention the new character sheet hotkey in the README

## Testing
- `python -m py_compile pRoguelike.py classes/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6840294b7c0c832bba715d0fd8c3991b