### PR TITLE
Improve auto-explore path planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ Use the arrow keys or the number pad for movement. Diagonal steps are mapped to
 `1`, `3`, `7`, and `9` on the number pad. Press `Q` during play to begin the
 quit process.
 
-Press `0` on the number pad to auto-explore the dungeon. Exploration pauses
-whenever you spot a monster, and pressing any key will immediately return
-control to you.
+Press `0` on the number pad to auto-explore the dungeon. The explorer always
+heads toward the closest unexplored location based on the shortest available
+path. Exploration pauses whenever you spot a monster, and pressing any key will
+immediately return control to you.
 
 While in the dungeon, press `i` to open your inventory. Press the letter
 corresponding to an equipment item to wear or wield it. Any item already in that

--- a/classes/game.py
+++ b/classes/game.py
@@ -458,23 +458,30 @@ class Game:
             self.walk_to(self.stairs_x, self.stairs_y, animate=True)
 
     def find_nearest_unexplored(self):
-        """Return coordinates of the nearest unexplored tile reachable from the player."""
-        from collections import deque
+        """Return coordinates of the nearest unexplored tile reachable from the
+        player using path length as the metric."""
+        from heapq import heappush, heappop
 
         start = (self.player.x, self.player.y)
-        queue = deque([start])
-        visited = {start}
+        heap = [(0, start)]
+        visited = set()
 
-        while queue:
-            x, y = queue.popleft()
+        while heap:
+            dist, (x, y) = heappop(heap)
+            if (x, y) in visited:
+                continue
+            visited.add((x, y))
+
             if not self.explored[y][x] and self.map[y][x] in ['.', '<', '>']:
                 return (x, y)
-            for dx, dy in [(-1,0),(1,0),(0,-1),(0,1),(-1,-1),(1,-1),(-1,1),(1,1)]:
+
+            for dx, dy in [(-1,0), (1,0), (0,-1), (0,1),
+                           (-1,-1), (1,-1), (-1,1), (1,1)]:
                 nx, ny = x + dx, y + dy
                 if (0 <= nx < self.width and 0 <= ny < self.height and
-                        (nx, ny) not in visited and self.map[ny][nx] in ['.', '<', '>']):
-                    visited.add((nx, ny))
-                    queue.append((nx, ny))
+                        self.map[ny][nx] in ['.', '<', '>'] and
+                        (nx, ny) not in visited):
+                    heappush(heap, (dist + 1, (nx, ny)))
         return None
 
     def auto_explore(self):


### PR DESCRIPTION
## Summary
- search for unexplored tiles with Dijkstra instead of plain BFS
- mention shortest path search in the README

## Testing
- `python -m py_compile classes/*.py pRoguelike.py`

------
https://chatgpt.com/codex/tasks/task_e_68402e00a940832bbd4dfd6fc1ab799f