### PR TITLE
Add options menu and expand debug gear

### DIFF
--- a/classes/game.py
+++ b/classes/game.py
@@ -63,6 +63,8 @@ class Game:
         self.quit = False
         self.walk_mode = False
         self.auto_explore_mode = False
+        self.options_mode = False
+        self.walk_speed = 5  # milliseconds between auto-move steps
 
     def open_character_stats_screen(self):
         self.character_stats_mode = True
@@ -101,17 +103,14 @@ class Game:
     def create_specific_item(self, category):
         if category == 'potion':
             template = random.choice(all_consumables)
-        elif category == 'weapon':
-            pool = [e for e in all_equipment if e.slot in ['weapon', 'missile weapon']]
-            template = random.choice(pool)
-        elif category == 'armor':
-            pool = [e for e in all_equipment if e.slot == 'armor']
-            template = random.choice(pool)
-        elif category == 'accessory':
-            pool = [e for e in all_equipment if e.slot not in ['weapon', 'missile weapon', 'armor']]
-            template = random.choice(pool)
         else:
-            template = random.choice(all_items)
+            if category == 'ring':
+                pool = [e for e in all_equipment if e.slot.startswith('ring')]
+            else:
+                pool = [e for e in all_equipment if e.slot == category]
+            if not pool:
+                pool = all_equipment
+            template = random.choice(pool)
 
         if isinstance(template, Equipment):
             material = random.choice(all_materials)
@@ -439,7 +438,7 @@ class Game:
 
                 if animate and self.stdscr:
                     self.renderer.draw(self.stdscr)
-                    time.sleep(0.005)
+                    time.sleep(self.walk_speed / 1000.0)
 
                 if (self.player.x, self.player.y) == (prev_x, prev_y):
                     break

--- a/classes/input_handler.py
+++ b/classes/input_handler.py
@@ -11,6 +11,10 @@ class InputHandler:
             self.handle_debug_input(key)
             return False  # Don't exit the game
 
+        if self.game.options_mode:
+            self.handle_options_input(key)
+            return False
+
         if self.game.inventory_mode:
             self.handle_inventory_input(key)
         elif self.game.backpack_mode:
@@ -60,6 +64,10 @@ class InputHandler:
 
         if key == ord('0'):
             self.game.auto_explore()
+            return
+
+        if key == ord('='):
+            self.game.options_mode = True
             return
 
         movement_keys = {
@@ -172,6 +180,18 @@ class InputHandler:
         elif 97 <= key <= 122:  # a-z
             self.game.use_backpack_item(chr(key))
 
+    def handle_options_input(self, key):
+        if key == 27:  # ESC
+            self.game.options_mode = False
+            return
+
+        if key in [ord('+'), curses.KEY_RIGHT]:
+            self.game.walk_speed = min(1000, self.game.walk_speed + 10)
+        elif key in [ord('-'), curses.KEY_LEFT]:
+            self.game.walk_speed = max(0, self.game.walk_speed - 10)
+        elif key in [10, 13]:
+            self.game.options_mode = False
+
     def handle_debug_input(self, key):
         # If the menu isn't open yet, hitting '!' will open it
         if not self.game.debug_mode and key == ord('!'):
@@ -182,29 +202,31 @@ class InputHandler:
             self.game.debug_mode = False
             return
 
-        if key == ord('a'):
-            item = self.game.create_specific_item('weapon')
+        item_keys = {
+            'a': 'weapon',
+            'b': 'missile weapon',
+            'c': 'helmet',
+            'd': 'amulet',
+            'e': 'shield',
+            'f': 'armor',
+            'g': 'cloak',
+            'h': 'girdle',
+            'i': 'gauntlets',
+            'j': 'boots',
+            'k': 'ring',
+            'l': 'bracers',
+            'm': 'potion',
+        }
+
+        if chr(key) in item_keys:
+            category = item_keys[chr(key)]
+            item = self.game.create_specific_item(category)
             self.game.player.add_item(item)
             self.game.messages.append(f"Created {item.name} in your inventory.")
             self.game.debug_mode = False
-        elif key == ord('b'):
-            item = self.game.create_specific_item('armor')
-            self.game.player.add_item(item)
-            self.game.messages.append(f"Created {item.name} in your inventory.")
-            self.game.debug_mode = False
-        elif key == ord('c'):
-            item = self.game.create_specific_item('accessory')
-            self.game.player.add_item(item)
-            self.game.messages.append(f"Created {item.name} in your inventory.")
-            self.game.debug_mode = False
-        elif key == ord('d'):
-            item = self.game.create_specific_item('potion')
-            self.game.player.add_item(item)
-            self.game.messages.append(f"Created {item.name} in your inventory.")
-            self.game.debug_mode = False
-        elif key == ord('e'):
+        elif key == ord('n'):
             self.game.map_current_level()
             self.game.debug_mode = False
-        elif key == ord('f'):
+        elif key == ord('o'):
             self.game.level_up_player()
             self.game.debug_mode = False

--- a/classes/renderer.py
+++ b/classes/renderer.py
@@ -265,14 +265,37 @@ class Renderer:
         menu_text = [
             "Cheat Menu (press escape to exit):",
             "a) Create weapon",
-            "b) Create armor",
-            "c) Create accessory",
-            "d) Create potion",
-            "e) Map level",
-            "f) Level up",
+            "b) Create missile weapon",
+            "c) Create helmet",
+            "d) Create amulet",
+            "e) Create shield",
+            "f) Create armor",
+            "g) Create cloak",
+            "h) Create girdle",
+            "i) Create gauntlets",
+            "j) Create boots",
+            "k) Create ring",
+            "l) Create bracers",
+            "m) Create potion",
+            "n) Map level",
+            "o) Level up",
         ]
 
         for i, line in enumerate(menu_text):
+            stdscr.addstr(i, 0, line[:width-1])
+
+        stdscr.refresh()
+
+    def draw_options_menu(self, stdscr):
+        stdscr.clear()
+        height, width = stdscr.getmaxyx()
+
+        lines = [
+            "Options (press escape to exit):",
+            f"Walking speed: {self.game.walk_speed} ms (+/- to adjust)",
+        ]
+
+        for i, line in enumerate(lines):
             stdscr.addstr(i, 0, line[:width-1])
 
         stdscr.refresh()

--- a/pRoguelike.py
+++ b/pRoguelike.py
@@ -70,6 +70,8 @@ def main(stdscr):
             game.renderer.draw_backpack(stdscr)
         elif game.drop_mode:
             game.renderer.draw_drop_interface(stdscr)
+        elif game.options_mode:
+            game.renderer.draw_options_menu(stdscr)
         elif game.debug_mode:
             game.renderer.draw_debug_menu(stdscr)
         else:


### PR DESCRIPTION
## Summary
- add `=` options command for adjusting walking speed
- support walking speed in `walk_to` and auto-explore
- extend debug menu with all gear type options
- display new options menu in renderer and main loop

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684031c8a82c832bad02b7d1feda609e