### PR TITLE
Fix auto-explore to map walls

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ Use the arrow keys or the number pad for movement. Diagonal steps are mapped to
 quit process.
 
 Press `0` on the number pad to auto-explore the dungeon. The explorer always
-heads toward the closest unexplored location based on the shortest available
-path. Exploration pauses whenever you spot a monster, and pressing any key will
+heads toward the closest unexplored location — including unrevealed walls —
+based on the shortest available path. Exploration pauses whenever you spot a
+monster, and pressing any key will
 immediately return control to you.
 
 While in the dungeon, press `i` to open your inventory. Press the letter

--- a/classes/game.py
+++ b/classes/game.py
@@ -457,8 +457,8 @@ class Game:
             self.walk_to(self.stairs_x, self.stairs_y, animate=True)
 
     def find_nearest_unexplored(self):
-        """Return coordinates of the nearest unexplored tile reachable from the
-        player using path length as the metric."""
+        """Return coordinates of the nearest tile that will reveal unexplored
+        areas when the player walks there."""
         from heapq import heappush, heappop
 
         start = (self.player.x, self.player.y)
@@ -471,8 +471,18 @@ class Game:
                 continue
             visited.add((x, y))
 
-            if not self.explored[y][x] and self.map[y][x] in ['.', '<', '>']:
+            # If this tile itself is unexplored, walking onto it will explore it
+            if not self.explored[y][x]:
                 return (x, y)
+
+            # If any adjacent tile is unexplored (including walls), moving here
+            # will reveal it via the field of view
+            for dx, dy in [(-1,0), (1,0), (0,-1), (0,1),
+                           (-1,-1), (1,-1), (-1,1), (1,1)]:
+                nx, ny = x + dx, y + dy
+                if 0 <= nx < self.width and 0 <= ny < self.height:
+                    if not self.explored[ny][nx]:
+                        return (x, y)
 
             for dx, dy in [(-1,0), (1,0), (0,-1), (0,1),
                            (-1,-1), (1,-1), (-1,1), (1,1)]:


### PR DESCRIPTION
## Summary
- improve auto-explore logic so that unseen walls are treated as unexplored
- document that auto-explore now reveals unrevealed walls

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684035819724832b844aa5a0c0c5f0c0