### PR TITLE
Add additional base items for boots, armor and amulets

### DIFF
--- a/data/items/amulets.json
+++ b/data/items/amulets.json
@@ -13,5 +13,20 @@
     "name": "Talisman",
     "char": "\"",
     "slot": "amulet"
+  },
+  {
+    "name": "Charm",
+    "char": "\"",
+    "slot": "amulet"
+  },
+  {
+    "name": "Medallion",
+    "char": "\"",
+    "slot": "amulet"
+  },
+  {
+    "name": "Torque",
+    "char": "\"",
+    "slot": "amulet"
   }
 ]

--- a/data/items/armor.json
+++ b/data/items/armor.json
@@ -13,5 +13,20 @@
     "name": "Plate Armor",
     "char": "[",
     "slot": "armor"
+  },
+  {
+    "name": "Leather Armor",
+    "char": "[",
+    "slot": "armor"
+  },
+  {
+    "name": "Scale Mail",
+    "char": "[",
+    "slot": "armor"
+  },
+  {
+    "name": "Breastplate",
+    "char": "[",
+    "slot": "armor"
   }
 ]

--- a/data/items/boots.json
+++ b/data/items/boots.json
@@ -13,5 +13,20 @@
     "name": "Greaves",
     "char": "(",
     "slot": "boots"
+  },
+  {
+    "name": "Shoes",
+    "char": "(",
+    "slot": "boots"
+  },
+  {
+    "name": "Sabatons",
+    "char": "(",
+    "slot": "boots"
+  },
+  {
+    "name": "High Boots",
+    "char": "(",
+    "slot": "boots"
   }
 ]


### PR DESCRIPTION
## Summary
- populate base equipment lists for boots, armor and amulets

## Testing
- `python -m py_compile classes/*.py pRoguelike.py`
- `python - <<'PY'
from classes.item_loader import all_equipment
print(len(all_equipment))
print([item.name for item in all_equipment if item.name in ("Leather Armor","Sabatons","Torque")])
PY`

------
https://chatgpt.com/codex/tasks/task_e_6840364664dc832b87f9d27ea91df110