### PR TITLE
Add help screen and numeric speed option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ slot will be returned to your pack automatically.
 
 Press `@` to view your character sheet, which lists your statistics and all
 currently equipped items.
+
+Press `=` to open the options menu.  Enter a value between `0` and `1000`
+to set how quickly auto-walking steps are animated.
+
+Press `?` at any time to see a quick reference of available commands.
 =======
 
 ### Note on Escape Key Responsiveness

--- a/classes/game.py
+++ b/classes/game.py
@@ -65,6 +65,8 @@ class Game:
         self.auto_explore_mode = False
         self.options_mode = False
         self.walk_speed = 5  # milliseconds between auto-move steps
+        self.help_mode = False
+        self.speed_input = ""
 
     def open_character_stats_screen(self):
         self.character_stats_mode = True

--- a/classes/input_handler.py
+++ b/classes/input_handler.py
@@ -11,6 +11,10 @@ class InputHandler:
             self.handle_debug_input(key)
             return False  # Don't exit the game
 
+        if self.game.help_mode:
+            self.handle_help_input(key)
+            return False
+
         if self.game.options_mode:
             self.handle_options_input(key)
             return False
@@ -68,6 +72,9 @@ class InputHandler:
 
         if key == ord('='):
             self.game.options_mode = True
+            return
+        if key == ord('?'):
+            self.game.help_mode = True
             return
 
         movement_keys = {
@@ -183,14 +190,29 @@ class InputHandler:
     def handle_options_input(self, key):
         if key == 27:  # ESC
             self.game.options_mode = False
+            self.game.speed_input = ""
             return
 
         if key in [ord('+'), curses.KEY_RIGHT]:
             self.game.walk_speed = min(1000, self.game.walk_speed + 10)
         elif key in [ord('-'), curses.KEY_LEFT]:
             self.game.walk_speed = max(0, self.game.walk_speed - 10)
+        elif ord('0') <= key <= ord('9'):
+            self.game.speed_input += chr(key)
+            if len(self.game.speed_input) > 4:
+                self.game.speed_input = self.game.speed_input[-4:]
+        elif key in (curses.KEY_BACKSPACE, 127, 8):
+            self.game.speed_input = self.game.speed_input[:-1]
         elif key in [10, 13]:
+            if self.game.speed_input:
+                value = int(self.game.speed_input)
+                self.game.walk_speed = max(0, min(1000, value))
+            self.game.speed_input = ""
             self.game.options_mode = False
+
+    def handle_help_input(self, key):
+        if key in (27, ord('q')):
+            self.game.help_mode = False
 
     def handle_debug_input(self, key):
         # If the menu isn't open yet, hitting '!' will open it

--- a/classes/renderer.py
+++ b/classes/renderer.py
@@ -292,10 +292,38 @@ class Renderer:
 
         lines = [
             "Options (press escape to exit):",
-            f"Walking speed: {self.game.walk_speed} ms (+/- to adjust)",
+            f"Walking speed: {self.game.walk_speed} ms (enter 0-1000)",
+        ]
+
+        if self.game.speed_input:
+            lines.append(f"New speed: {self.game.speed_input}")
+
+        for i, line in enumerate(lines):
+            stdscr.addstr(i, 0, line[:width-1])
+
+        stdscr.refresh()
+
+    def draw_help_menu(self, stdscr):
+        stdscr.clear()
+        height, width = stdscr.getmaxyx()
+
+        lines = [
+            "Help (press escape to exit):",
+            "Movement: hjkl or arrow keys; diagonals yubn",
+            "Wait: 5",
+            "Pick up item: ','",
+            "Open inventory: i",
+            "Character info: @",
+            "Auto-explore: 0",
+            "Walk to stairs: w",
+            "Options menu: =",
+            "Quit game: Q",
+            "Show this help: ?",
         ]
 
         for i, line in enumerate(lines):
+            if i >= height:
+                break
             stdscr.addstr(i, 0, line[:width-1])
 
         stdscr.refresh()

--- a/pRoguelike.py
+++ b/pRoguelike.py
@@ -72,6 +72,8 @@ def main(stdscr):
             game.renderer.draw_drop_interface(stdscr)
         elif game.options_mode:
             game.renderer.draw_options_menu(stdscr)
+        elif game.help_mode:
+            game.renderer.draw_help_menu(stdscr)
         elif game.debug_mode:
             game.renderer.draw_debug_menu(stdscr)
         else:


### PR DESCRIPTION
## Summary
- allow specifying walking speed numerically
- display typed speed while in options
- add in-game help menu triggered with `?`
- document options and help features

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840381d3f68832b8569cdd3b77ecf43