### PR TITLE
Add power stats and body slots to items

### DIFF
--- a/classes/entity.py
+++ b/classes/entity.py
@@ -164,9 +164,11 @@ class Entity:
         if dagger_base and bronze:
             dagger = Equipment(
                 f"{bronze.name} {dagger_base.name}",
-                dagger_base.char,
                 dagger_base.slot,
+                dagger_base.body_part,
                 bronze.power,
+                damage=dagger_base.damage,
+                ac=dagger_base.ac,
                 accuracy_bonus=dagger_base.accuracy_bonus,
             )
             self.equip(dagger, 'a')  # 'a' is the weapon slot
@@ -174,9 +176,11 @@ class Entity:
         if robe_base and cloth:
             robe = Equipment(
                 f"{cloth.name} {robe_base.name}",
-                robe_base.char,
                 robe_base.slot,
+                robe_base.body_part,
                 cloth.power,
+                damage=robe_base.damage,
+                ac=robe_base.ac,
             )
             self.equip(robe, 'f')  # 'f' is the armor slot
 

--- a/classes/game.py
+++ b/classes/game.py
@@ -94,13 +94,15 @@ class Game:
             stat = material.power
             return Equipment(
                 name,
-                item_template.char,
                 item_template.slot,
+                item_template.body_part,
                 stat,
+                damage=item_template.damage,
+                ac=item_template.ac,
                 accuracy_bonus=item_template.accuracy_bonus,
             )
         else:
-            return Item(item_template.name, item_template.char, item_template.effect)
+            return Item(item_template.name, item_template.effect)
 
     def create_specific_item(self, category):
         if category == 'potion':
@@ -120,13 +122,15 @@ class Game:
             stat = material.power
             return Equipment(
                 name,
-                template.char,
                 template.slot,
+                template.body_part,
                 stat,
+                damage=template.damage,
+                ac=template.ac,
                 accuracy_bonus=template.accuracy_bonus,
             )
         else:
-            return Item(template.name, template.char, template.effect)
+            return Item(template.name, template.effect)
 
     def map_current_level(self):
         for y in range(self.height):
@@ -244,7 +248,7 @@ class Game:
             defense = int((random.randint(0, 3) + self.dungeon_level // 2) * difficulty_factor)
             enemy = Entity(x, y, 'E', f"Enemy Lv{self.dungeon_level}", health, damage, defense)
             if random.random() < 0.3:
-                enemy.add_item(Item("Health Potion", '!', lambda e: setattr(e, 'health', min(e.max_health, e.health + 20))))
+                enemy.add_item(Item("Health Potion", lambda e: setattr(e, 'health', min(e.max_health, e.health + 20))))
             self.enemies.append(enemy)
 
     def get_random_floor(self):

--- a/classes/item.py
+++ b/classes/item.py
@@ -1,7 +1,6 @@
 class Item:
-    def __init__(self, name, char, effect, duration=None):
+    def __init__(self, name, effect, duration=None):
         self.name = name
-        self.char = char
         self.effect = effect
         self.duration = duration
         self.x = None
@@ -17,9 +16,12 @@ class Item:
         return hash(self.name)
 
 class Equipment(Item):
-    def __init__(self, name, char, slot, stat_boost, accuracy_bonus=0):
-        super().__init__(name, char, None)
+    def __init__(self, name, slot, body_part, stat_boost, damage=None, ac=None, accuracy_bonus=0):
+        super().__init__(name, None)
         self.slot = slot
+        self.body_part = body_part
+        self.damage = damage
+        self.ac = ac
         self.stat_boost = stat_boost
 
         # Separate bonuses allow items to affect different stats

--- a/classes/item_loader.py
+++ b/classes/item_loader.py
@@ -22,7 +22,7 @@ def load_items():
     consumables = []
     for item_data in consumable_data:
         effect = create_effect(item_data['effect'], item_data['value'])
-        item = Item(item_data['name'], item_data['char'], effect, item_data.get('duration', None))
+        item = Item(item_data['name'], effect, item_data.get('duration', None))
         consumables.append(item)
 
     materials = [Material(m['name'], m['power']) for m in material_data]
@@ -38,9 +38,11 @@ def load_items():
             accuracy = item_data.get('accuracy', 0)
             item = Equipment(
                 item_data['name'],
-                item_data['char'],
                 item_data['slot'],
+                item_data.get('body_part', 'unknown'),
                 0,
+                damage=item_data.get('damage'),
+                ac=item_data.get('ac'),
                 accuracy_bonus=accuracy,
             )
             equipment.append(item)

--- a/classes/renderer.py
+++ b/classes/renderer.py
@@ -2,9 +2,30 @@ import curses
 
 from classes.item import Equipment
 
+ITEM_ICONS = {
+    'weapon': '/',
+    'missile weapon': '}',
+    'helmet': '^',
+    'armor': '[',
+    'cloak': 'B',
+    'shield': ')',
+    'boots': '(',
+    'bracers': '|',
+    'gauntlets': ']',
+    'girdle': ':',
+    'amulet': '"',
+    'ring (right)': '=',
+    'ring (left)': '=',
+}
+
 class Renderer:
     def __init__(self, game):
         self.game = game
+
+    def _icon_for(self, item):
+        if isinstance(item, Equipment):
+            return ITEM_ICONS.get(item.slot, '?')
+        return '!'
 
     def draw(self, stdscr):
         stdscr.clear()
@@ -31,7 +52,8 @@ class Renderer:
 
         for item in self.game.items:
             if item.y < dungeon_height and self.game.visible[item.y][item.x]:
-                stdscr.addch(item.y, item.x, item.char, curses.color_pair(4))  # Items
+                icon = self._icon_for(item)
+                stdscr.addch(item.y, item.x, icon, curses.color_pair(4))  # Items
 
         for enemy in self.game.enemies:
             if enemy.y < dungeon_height and self.game.visible[enemy.y][enemy.x]:

--- a/data/items/amulets.json
+++ b/data/items/amulets.json
@@ -1,52 +1,62 @@
 [
   {
     "name": "Pendant",
-    "char": "\"",
-    "slot": "amulet"
+    "slot": "amulet",
+    "body_part": "neck",
+    "ac": 1
   },
   {
     "name": "Amulet",
-    "char": "\"",
-    "slot": "amulet"
+    "slot": "amulet",
+    "body_part": "neck",
+    "ac": 1
   },
   {
     "name": "Talisman",
-    "char": "\"",
-    "slot": "amulet"
+    "slot": "amulet",
+    "body_part": "neck",
+    "ac": 1
   },
   {
     "name": "Charm",
-    "char": "\"",
-    "slot": "amulet"
+    "slot": "amulet",
+    "body_part": "neck",
+    "ac": 1
   },
   {
     "name": "Medallion",
-    "char": "\"",
-    "slot": "amulet"
+    "slot": "amulet",
+    "body_part": "neck",
+    "ac": 1
   },
   {
     "name": "Torque",
-    "char": "\"",
-    "slot": "amulet"
+    "slot": "amulet",
+    "body_part": "neck",
+    "ac": 1
   },
   {
     "name": "Locket",
-    "char": "\"",
-    "slot": "amulet"
+    "slot": "amulet",
+    "body_part": "neck",
+    "ac": 1
   },
   {
     "name": "Phylactery",
-    "char": "\"",
-    "slot": "amulet"
+    "slot": "amulet",
+    "body_part": "neck",
+    "ac": 1
   },
   {
     "name": "Gorget",
-    "char": "\"",
-    "slot": "amulet"
+    "slot": "amulet",
+    "body_part": "neck",
+    "ac": 1
   },
   {
     "name": "Collar",
-    "char": "\"",
-    "slot": "amulet"
+    "slot": "amulet",
+    "body_part": "neck",
+    "ac": 1
   }
 ]

--- a/data/items/armor.json
+++ b/data/items/armor.json
@@ -1,52 +1,62 @@
 [
   {
     "name": "Robe",
-    "char": "[",
-    "slot": "armor"
+    "slot": "armor",
+    "body_part": "torso",
+    "ac": 3
   },
   {
     "name": "Chain Mail",
-    "char": "[",
-    "slot": "armor"
+    "slot": "armor",
+    "body_part": "torso",
+    "ac": 3
   },
   {
     "name": "Plate Armor",
-    "char": "[",
-    "slot": "armor"
+    "slot": "armor",
+    "body_part": "torso",
+    "ac": 3
   },
   {
     "name": "Leather Armor",
-    "char": "[",
-    "slot": "armor"
+    "slot": "armor",
+    "body_part": "torso",
+    "ac": 3
   },
   {
     "name": "Scale Mail",
-    "char": "[",
-    "slot": "armor"
+    "slot": "armor",
+    "body_part": "torso",
+    "ac": 3
   },
   {
     "name": "Breastplate",
-    "char": "[",
-    "slot": "armor"
+    "slot": "armor",
+    "body_part": "torso",
+    "ac": 3
   },
   {
     "name": "Lamellar Armor",
-    "char": "[",
-    "slot": "armor"
+    "slot": "armor",
+    "body_part": "torso",
+    "ac": 3
   },
   {
     "name": "Quilted Armor",
-    "char": "[",
-    "slot": "armor"
+    "slot": "armor",
+    "body_part": "torso",
+    "ac": 3
   },
   {
     "name": "Ring Mail",
-    "char": "[",
-    "slot": "armor"
+    "slot": "armor",
+    "body_part": "torso",
+    "ac": 3
   },
   {
     "name": "Banded Mail",
-    "char": "[",
-    "slot": "armor"
+    "slot": "armor",
+    "body_part": "torso",
+    "ac": 3
   }
 ]

--- a/data/items/boots.json
+++ b/data/items/boots.json
@@ -1,52 +1,62 @@
 [
   {
     "name": "Sandals",
-    "char": "(",
-    "slot": "boots"
+    "slot": "boots",
+    "body_part": "feet",
+    "ac": 1
   },
   {
     "name": "Boots",
-    "char": "(",
-    "slot": "boots"
+    "slot": "boots",
+    "body_part": "feet",
+    "ac": 1
   },
   {
     "name": "Greaves",
-    "char": "(",
-    "slot": "boots"
+    "slot": "boots",
+    "body_part": "feet",
+    "ac": 1
   },
   {
     "name": "Shoes",
-    "char": "(",
-    "slot": "boots"
+    "slot": "boots",
+    "body_part": "feet",
+    "ac": 1
   },
   {
     "name": "Sabatons",
-    "char": "(",
-    "slot": "boots"
+    "slot": "boots",
+    "body_part": "feet",
+    "ac": 1
   },
   {
     "name": "High Boots",
-    "char": "(",
-    "slot": "boots"
+    "slot": "boots",
+    "body_part": "feet",
+    "ac": 1
   },
   {
     "name": "Moccasins",
-    "char": "(",
-    "slot": "boots"
+    "slot": "boots",
+    "body_part": "feet",
+    "ac": 1
   },
   {
     "name": "Slippers",
-    "char": "(",
-    "slot": "boots"
+    "slot": "boots",
+    "body_part": "feet",
+    "ac": 1
   },
   {
     "name": "Waders",
-    "char": "(",
-    "slot": "boots"
+    "slot": "boots",
+    "body_part": "feet",
+    "ac": 1
   },
   {
     "name": "Riding Boots",
-    "char": "(",
-    "slot": "boots"
+    "slot": "boots",
+    "body_part": "feet",
+    "ac": 1
   }
 ]

--- a/data/items/bracers.json
+++ b/data/items/bracers.json
@@ -1,52 +1,62 @@
 [
   {
     "name": "Wristguards",
-    "char": "|",
-    "slot": "bracers"
+    "slot": "bracers",
+    "body_part": "arms",
+    "ac": 1
   },
   {
     "name": "Bracers",
-    "char": "|",
-    "slot": "bracers"
+    "slot": "bracers",
+    "body_part": "arms",
+    "ac": 1
   },
   {
     "name": "Armguards",
-    "char": "|",
-    "slot": "bracers"
+    "slot": "bracers",
+    "body_part": "arms",
+    "ac": 1
   },
   {
     "name": "Cuffs",
-    "char": "|",
-    "slot": "bracers"
+    "slot": "bracers",
+    "body_part": "arms",
+    "ac": 1
   },
   {
     "name": "Armlets",
-    "char": "|",
-    "slot": "bracers"
+    "slot": "bracers",
+    "body_part": "arms",
+    "ac": 1
   },
   {
     "name": "Leather Bracers",
-    "char": "|",
-    "slot": "bracers"
+    "slot": "bracers",
+    "body_part": "arms",
+    "ac": 1
   },
   {
     "name": "Plate Bracers",
-    "char": "|",
-    "slot": "bracers"
+    "slot": "bracers",
+    "body_part": "arms",
+    "ac": 1
   },
   {
     "name": "Studded Bracers",
-    "char": "|",
-    "slot": "bracers"
+    "slot": "bracers",
+    "body_part": "arms",
+    "ac": 1
   },
   {
     "name": "Forearm Guards",
-    "char": "|",
-    "slot": "bracers"
+    "slot": "bracers",
+    "body_part": "arms",
+    "ac": 1
   },
   {
     "name": "Enchanted Bracers",
-    "char": "|",
-    "slot": "bracers"
+    "slot": "bracers",
+    "body_part": "arms",
+    "ac": 1
   }
 ]

--- a/data/items/cloaks.json
+++ b/data/items/cloaks.json
@@ -1,52 +1,62 @@
 [
   {
     "name": "Cloak",
-    "char": "B",
-    "slot": "cloak"
+    "slot": "cloak",
+    "body_part": "back",
+    "ac": 1
   },
   {
     "name": "Cape",
-    "char": "B",
-    "slot": "cloak"
+    "slot": "cloak",
+    "body_part": "back",
+    "ac": 1
   },
   {
     "name": "Mantle",
-    "char": "B",
-    "slot": "cloak"
+    "slot": "cloak",
+    "body_part": "back",
+    "ac": 1
   },
   {
     "name": "Hooded Cloak",
-    "char": "B",
-    "slot": "cloak"
+    "slot": "cloak",
+    "body_part": "back",
+    "ac": 1
   },
   {
     "name": "Traveling Cloak",
-    "char": "B",
-    "slot": "cloak"
+    "slot": "cloak",
+    "body_part": "back",
+    "ac": 1
   },
   {
     "name": "Opera Cape",
-    "char": "B",
-    "slot": "cloak"
+    "slot": "cloak",
+    "body_part": "back",
+    "ac": 1
   },
   {
     "name": "Duster",
-    "char": "B",
-    "slot": "cloak"
+    "slot": "cloak",
+    "body_part": "back",
+    "ac": 1
   },
   {
     "name": "Pelerine",
-    "char": "B",
-    "slot": "cloak"
+    "slot": "cloak",
+    "body_part": "back",
+    "ac": 1
   },
   {
     "name": "Shroud",
-    "char": "B",
-    "slot": "cloak"
+    "slot": "cloak",
+    "body_part": "back",
+    "ac": 1
   },
   {
     "name": "Poncho",
-    "char": "B",
-    "slot": "cloak"
+    "slot": "cloak",
+    "body_part": "back",
+    "ac": 1
   }
 ]

--- a/data/items/consumables.json
+++ b/data/items/consumables.json
@@ -1,61 +1,51 @@
 [
   {
     "name": "Health Potion",
-    "char": "!",
     "effect": "heal",
     "value": 20
   },
   {
     "name": "Greater Health Potion",
-    "char": "!",
     "effect": "heal",
     "value": 50
   },
   {
     "name": "Mana Potion",
-    "char": "!",
     "effect": "restore_mana",
     "value": 20
   },
   {
     "name": "Greater Mana Potion",
-    "char": "!",
     "effect": "restore_mana",
     "value": 50
   },
   {
     "name": "Strength Elixir",
-    "char": "!",
     "effect": "boost_strength",
     "value": 2
   },
   {
     "name": "Dexterity Elixir",
-    "char": "!",
     "effect": "boost_dexterity",
     "value": 2
   },
   {
     "name": "Minor Health Potion",
-    "char": "!",
     "effect": "heal",
     "value": 10
   },
   {
     "name": "Major Mana Potion",
-    "char": "!",
     "effect": "restore_mana",
     "value": 75
   },
   {
     "name": "Strength Draught",
-    "char": "!",
     "effect": "boost_strength",
     "value": 3
   },
   {
     "name": "Dexterity Draught",
-    "char": "!",
     "effect": "boost_dexterity",
     "value": 3
   }

--- a/data/items/gauntlets.json
+++ b/data/items/gauntlets.json
@@ -1,52 +1,62 @@
 [
   {
     "name": "Gloves",
-    "char": "]",
-    "slot": "gauntlets"
+    "slot": "gauntlets",
+    "body_part": "hands",
+    "ac": 1
   },
   {
     "name": "Gauntlets",
-    "char": "]",
-    "slot": "gauntlets"
+    "slot": "gauntlets",
+    "body_part": "hands",
+    "ac": 1
   },
   {
     "name": "Vambraces",
-    "char": "]",
-    "slot": "gauntlets"
+    "slot": "gauntlets",
+    "body_part": "hands",
+    "ac": 1
   },
   {
     "name": "Mitts",
-    "char": "]",
-    "slot": "gauntlets"
+    "slot": "gauntlets",
+    "body_part": "hands",
+    "ac": 1
   },
   {
     "name": "Plate Gauntlets",
-    "char": "]",
-    "slot": "gauntlets"
+    "slot": "gauntlets",
+    "body_part": "hands",
+    "ac": 1
   },
   {
     "name": "Chain Gauntlets",
-    "char": "]",
-    "slot": "gauntlets"
+    "slot": "gauntlets",
+    "body_part": "hands",
+    "ac": 1
   },
   {
     "name": "Leather Gloves",
-    "char": "]",
-    "slot": "gauntlets"
+    "slot": "gauntlets",
+    "body_part": "hands",
+    "ac": 1
   },
   {
     "name": "Battle Gauntlets",
-    "char": "]",
-    "slot": "gauntlets"
+    "slot": "gauntlets",
+    "body_part": "hands",
+    "ac": 1
   },
   {
     "name": "Spiked Gauntlets",
-    "char": "]",
-    "slot": "gauntlets"
+    "slot": "gauntlets",
+    "body_part": "hands",
+    "ac": 1
   },
   {
     "name": "Enchanted Gloves",
-    "char": "]",
-    "slot": "gauntlets"
+    "slot": "gauntlets",
+    "body_part": "hands",
+    "ac": 1
   }
 ]

--- a/data/items/girdles.json
+++ b/data/items/girdles.json
@@ -1,52 +1,62 @@
 [
   {
     "name": "Belt",
-    "char": ":",
-    "slot": "girdle"
+    "slot": "girdle",
+    "body_part": "waist",
+    "ac": 1
   },
   {
     "name": "Chain Belt",
-    "char": ":",
-    "slot": "girdle"
+    "slot": "girdle",
+    "body_part": "waist",
+    "ac": 1
   },
   {
     "name": "Girdle",
-    "char": ":",
-    "slot": "girdle"
+    "slot": "girdle",
+    "body_part": "waist",
+    "ac": 1
   },
   {
     "name": "Rope Belt",
-    "char": ":",
-    "slot": "girdle"
+    "slot": "girdle",
+    "body_part": "waist",
+    "ac": 1
   },
   {
     "name": "Leather Girdle",
-    "char": ":",
-    "slot": "girdle"
+    "slot": "girdle",
+    "body_part": "waist",
+    "ac": 1
   },
   {
     "name": "Studded Belt",
-    "char": ":",
-    "slot": "girdle"
+    "slot": "girdle",
+    "body_part": "waist",
+    "ac": 1
   },
   {
     "name": "Sash",
-    "char": ":",
-    "slot": "girdle"
+    "slot": "girdle",
+    "body_part": "waist",
+    "ac": 1
   },
   {
     "name": "Corded Belt",
-    "char": ":",
-    "slot": "girdle"
+    "slot": "girdle",
+    "body_part": "waist",
+    "ac": 1
   },
   {
     "name": "Reinforced Belt",
-    "char": ":",
-    "slot": "girdle"
+    "slot": "girdle",
+    "body_part": "waist",
+    "ac": 1
   },
   {
     "name": "Heavy Girdle",
-    "char": ":",
-    "slot": "girdle"
+    "slot": "girdle",
+    "body_part": "waist",
+    "ac": 1
   }
 ]

--- a/data/items/helmets.json
+++ b/data/items/helmets.json
@@ -1,52 +1,62 @@
 [
   {
     "name": "Cap",
-    "char": "^",
-    "slot": "helmet"
+    "slot": "helmet",
+    "body_part": "head",
+    "ac": 1
   },
   {
     "name": "Helm",
-    "char": "^",
-    "slot": "helmet"
+    "slot": "helmet",
+    "body_part": "head",
+    "ac": 1
   },
   {
     "name": "Great Helm",
-    "char": "^",
-    "slot": "helmet"
+    "slot": "helmet",
+    "body_part": "head",
+    "ac": 1
   },
   {
     "name": "Hood",
-    "char": "^",
-    "slot": "helmet"
+    "slot": "helmet",
+    "body_part": "head",
+    "ac": 1
   },
   {
     "name": "Visored Helm",
-    "char": "^",
-    "slot": "helmet"
+    "slot": "helmet",
+    "body_part": "head",
+    "ac": 1
   },
   {
     "name": "Sallet",
-    "char": "^",
-    "slot": "helmet"
+    "slot": "helmet",
+    "body_part": "head",
+    "ac": 1
   },
   {
     "name": "Bascinet",
-    "char": "^",
-    "slot": "helmet"
+    "slot": "helmet",
+    "body_part": "head",
+    "ac": 1
   },
   {
     "name": "Barbute",
-    "char": "^",
-    "slot": "helmet"
+    "slot": "helmet",
+    "body_part": "head",
+    "ac": 1
   },
   {
     "name": "Kettle Helm",
-    "char": "^",
-    "slot": "helmet"
+    "slot": "helmet",
+    "body_part": "head",
+    "ac": 1
   },
   {
     "name": "Morion",
-    "char": "^",
-    "slot": "helmet"
+    "slot": "helmet",
+    "body_part": "head",
+    "ac": 1
   }
 ]

--- a/data/items/missile_weapons.json
+++ b/data/items/missile_weapons.json
@@ -1,102 +1,182 @@
 [
   {
     "name": "Light Crossbow",
-    "char": "}",
-    "slot": "missile weapon"
+    "slot": "missile weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 2,
+      "max": 8
+    }
   },
   {
     "name": "Heavy Crossbow",
-    "char": "}",
-    "slot": "missile weapon"
+    "slot": "missile weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 2,
+      "max": 8
+    }
   },
   {
     "name": "Repeating Crossbow",
-    "char": "}",
-    "slot": "missile weapon"
+    "slot": "missile weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 2,
+      "max": 8
+    }
   },
   {
     "name": "Siege Crossbow",
-    "char": "}",
-    "slot": "missile weapon"
+    "slot": "missile weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 2,
+      "max": 8
+    }
   },
   {
     "name": "Arbalest",
-    "char": "}",
-    "slot": "missile weapon"
+    "slot": "missile weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 2,
+      "max": 8
+    }
   },
   {
     "name": "Simple Longbow",
-    "char": "}",
-    "slot": "missile weapon"
+    "slot": "missile weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Composite Longbow",
-    "char": "}",
-    "slot": "missile weapon"
+    "slot": "missile weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Recurve Longbow",
-    "char": "}",
-    "slot": "missile weapon"
+    "slot": "missile weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Greatbow",
-    "char": "}",
-    "slot": "missile weapon"
+    "slot": "missile weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Elven Longbow",
-    "char": "}",
-    "slot": "missile weapon"
+    "slot": "missile weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Simple Shortbow",
-    "char": "}",
-    "slot": "missile weapon"
+    "slot": "missile weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Composite Shortbow",
-    "char": "}",
-    "slot": "missile weapon"
+    "slot": "missile weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Recurve Shortbow",
-    "char": "}",
-    "slot": "missile weapon"
+    "slot": "missile weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Hunting Bow",
-    "char": "}",
-    "slot": "missile weapon"
+    "slot": "missile weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Elven Shortbow",
-    "char": "}",
-    "slot": "missile weapon"
+    "slot": "missile weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Simple Sling",
-    "char": "}",
-    "slot": "missile weapon"
+    "slot": "missile weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 4
+    }
   },
   {
     "name": "Staff Sling",
-    "char": "}",
-    "slot": "missile weapon"
+    "slot": "missile weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 4
+    }
   },
   {
     "name": "Heavy Sling",
-    "char": "}",
-    "slot": "missile weapon"
+    "slot": "missile weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 4
+    }
   },
   {
     "name": "Whip Sling",
-    "char": "}",
-    "slot": "missile weapon"
+    "slot": "missile weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 4
+    }
   },
   {
     "name": "Precision Sling",
-    "char": "}",
-    "slot": "missile weapon"
+    "slot": "missile weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 4
+    }
   }
 ]

--- a/data/items/rings.json
+++ b/data/items/rings.json
@@ -1,52 +1,62 @@
 [
   {
     "name": "Ring",
-    "char": "=",
-    "slot": "ring (right)"
+    "slot": "ring (right)",
+    "body_part": "finger",
+    "ac": 1
   },
   {
     "name": "Band",
-    "char": "=",
-    "slot": "ring (right)"
+    "slot": "ring (right)",
+    "body_part": "finger",
+    "ac": 1
   },
   {
     "name": "Signet",
-    "char": "=",
-    "slot": "ring (right)"
+    "slot": "ring (right)",
+    "body_part": "finger",
+    "ac": 1
   },
   {
     "name": "Loop",
-    "char": "=",
-    "slot": "ring (right)"
+    "slot": "ring (right)",
+    "body_part": "finger",
+    "ac": 1
   },
   {
     "name": "Seal",
-    "char": "=",
-    "slot": "ring (right)"
+    "slot": "ring (right)",
+    "body_part": "finger",
+    "ac": 1
   },
   {
     "name": "Ring",
-    "char": "=",
-    "slot": "ring (left)"
+    "slot": "ring (left)",
+    "body_part": "finger",
+    "ac": 1
   },
   {
     "name": "Band",
-    "char": "=",
-    "slot": "ring (left)"
+    "slot": "ring (left)",
+    "body_part": "finger",
+    "ac": 1
   },
   {
     "name": "Signet",
-    "char": "=",
-    "slot": "ring (left)"
+    "slot": "ring (left)",
+    "body_part": "finger",
+    "ac": 1
   },
   {
     "name": "Loop",
-    "char": "=",
-    "slot": "ring (left)"
+    "slot": "ring (left)",
+    "body_part": "finger",
+    "ac": 1
   },
   {
     "name": "Seal",
-    "char": "=",
-    "slot": "ring (left)"
+    "slot": "ring (left)",
+    "body_part": "finger",
+    "ac": 1
   }
 ]

--- a/data/items/shields.json
+++ b/data/items/shields.json
@@ -1,52 +1,62 @@
 [
   {
     "name": "Buckler",
-    "char": ")",
-    "slot": "shield"
+    "slot": "shield",
+    "body_part": "hand",
+    "ac": 2
   },
   {
     "name": "Kite Shield",
-    "char": ")",
-    "slot": "shield"
+    "slot": "shield",
+    "body_part": "hand",
+    "ac": 2
   },
   {
     "name": "Tower Shield",
-    "char": ")",
-    "slot": "shield"
+    "slot": "shield",
+    "body_part": "hand",
+    "ac": 2
   },
   {
     "name": "Round Shield",
-    "char": ")",
-    "slot": "shield"
+    "slot": "shield",
+    "body_part": "hand",
+    "ac": 2
   },
   {
     "name": "Heater Shield",
-    "char": ")",
-    "slot": "shield"
+    "slot": "shield",
+    "body_part": "hand",
+    "ac": 2
   },
   {
     "name": "Pavise",
-    "char": ")",
-    "slot": "shield"
+    "slot": "shield",
+    "body_part": "hand",
+    "ac": 2
   },
   {
     "name": "Aegis",
-    "char": ")",
-    "slot": "shield"
+    "slot": "shield",
+    "body_part": "hand",
+    "ac": 2
   },
   {
     "name": "Wall Shield",
-    "char": ")",
-    "slot": "shield"
+    "slot": "shield",
+    "body_part": "hand",
+    "ac": 2
   },
   {
     "name": "Barrel Lid",
-    "char": ")",
-    "slot": "shield"
+    "slot": "shield",
+    "body_part": "hand",
+    "ac": 2
   },
   {
     "name": "Spiked Shield",
-    "char": ")",
-    "slot": "shield"
+    "slot": "shield",
+    "body_part": "hand",
+    "ac": 2
   }
 ]

--- a/data/items/weapons.json
+++ b/data/items/weapons.json
@@ -1,207 +1,371 @@
 [
   {
     "name": "Dagger",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 4
+    }
   },
   {
     "name": "Arming Sword",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Bastard Sword",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 8
+    }
   },
   {
     "name": "Claymore",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 8
+    }
   },
   {
     "name": "Flamberge",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 8
+    }
   },
   {
     "name": "Katana",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 8
+    }
   },
   {
     "name": "Gladius",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Falchion",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Cutlass",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Sabre",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Rapier",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Stiletto",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 4
+    }
   },
   {
     "name": "Dirk",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 4
+    }
   },
   {
     "name": "Kris",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 4
+    }
   },
   {
     "name": "Rondel",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 4
+    }
   },
   {
     "name": "Cinquedea",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 4
+    }
   },
   {
     "name": "Club",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 4
+    }
   },
   {
     "name": "Morning Star",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Flanged Mace",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Holy Mace",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "War Mace",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "War Hammer",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 8
+    }
   },
   {
     "name": "Maul",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 8
+    }
   },
   {
     "name": "Sledge Hammer",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 8
+    }
   },
   {
     "name": "Lucerne Hammer",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 8
+    }
   },
   {
     "name": "Forge Hammer",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 8
+    }
   },
   {
     "name": "Hand Axe",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Battle Axe",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 8
+    }
   },
   {
     "name": "Great Axe",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 8
+    }
   },
   {
     "name": "Double Axe",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 8
+    }
   },
   {
     "name": "Throwing Axe",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 4
+    }
   },
   {
     "name": "Short Spear",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Long Spear",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 8
+    }
   },
   {
     "name": "Javelin",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 4
+    }
   },
   {
     "name": "Pike",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 8
+    }
   },
   {
     "name": "Trident",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 6
+    }
   },
   {
     "name": "Halberd",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 8
+    }
   },
   {
     "name": "Glaive",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 8
+    }
   },
   {
     "name": "Naginata",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 8
+    }
   },
   {
     "name": "Bardiche",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 8
+    }
   },
   {
     "name": "Scythe",
-    "char": "/",
-    "slot": "weapon"
+    "slot": "weapon",
+    "body_part": "hands",
+    "damage": {
+      "min": 1,
+      "max": 8
+    }
   }
 ]

--- a/pRoguelike.py
+++ b/pRoguelike.py
@@ -11,6 +11,7 @@ os.environ.setdefault("ESCDELAY", "25")
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 
 from classes.game import Game
+from classes.item import Equipment
 from curses import KEY_NPAGE, KEY_PPAGE
 
 def draw(stdscr, game):
@@ -20,8 +21,27 @@ def draw(stdscr, game):
         for x, cell in enumerate(row):
             stdscr.addch(y, x, cell)
 
+    icon_map = {
+        'weapon': '/',
+        'missile weapon': '}',
+        'helmet': '^',
+        'armor': '[',
+        'cloak': 'B',
+        'shield': ')',
+        'boots': '(',
+        'bracers': '|',
+        'gauntlets': ']',
+        'girdle': ':',
+        'amulet': '"',
+        'ring (right)': '=',
+        'ring (left)': '=',
+    }
     for item in game.items:
-        stdscr.addch(item.y, item.x, item.char)
+        if isinstance(item, Equipment):
+            ch = icon_map.get(item.slot, '?')
+        else:
+            ch = '!'
+        stdscr.addch(item.y, item.x, ch)
 
     for enemy in game.enemies:
         stdscr.addch(enemy.y, enemy.x, enemy.char)


### PR DESCRIPTION
## Summary
- give all item JSON entries damage or armor values and body part info
- drop `char` field from items
- update data loader and item classes for new fields
- adapt game logic and rendering to work without item `char`

## Testing
- `python -m py_compile classes/*.py pRoguelike.py`

------
https://chatgpt.com/codex/tasks/task_e_68403be967ac832b890efa6421ad1eee