### PR TITLE
Display new stats and tweak combat

### DIFF
--- a/classes/combat_system.py
+++ b/classes/combat_system.py
@@ -9,8 +9,13 @@ class CombatSystem:
             None,
         )
         accuracy_bonus = weapon.accuracy_bonus if weapon else 0
-        attack_roll = random.randint(1, 20) + max(0, (attacker.strength - 10) // 2) + accuracy_bonus
-        defense_value = 10 + defender.defense + max(0, (defender.dexterity - 10) // 2)
+        attack_bonus = max(0, (attacker.strength - 10) // 2)
+        attack_bonus += max(0, (attacker.dexterity - 10) // 2)
+        attack_roll = random.randint(1, 20) + attack_bonus + accuracy_bonus
+
+        defense_bonus = max(0, (defender.dexterity - 10) // 2)
+        defense_bonus += max(0, (defender.constitution - 10) // 2)
+        defense_value = 10 + defender.defense + defense_bonus
 
         if attack_roll >= defense_value:
             damage = max(1, base_damage + random.randint(-2, 2))

--- a/classes/entity.py
+++ b/classes/entity.py
@@ -68,7 +68,8 @@ class Entity:
             if slot['item']
         )
         dexterity_bonus = max(0, (self.dexterity - 10) // 2)  # +1 for every 2 points above 10
-        return self.base_defense + armor_bonus + dexterity_bonus
+        constitution_bonus = max(0, (self.constitution - 10) // 2)
+        return self.base_defense + armor_bonus + dexterity_bonus + constitution_bonus
 
     def equip(self, item, slot_key):
         slot = self.equipment[slot_key]

--- a/classes/renderer.py
+++ b/classes/renderer.py
@@ -246,15 +246,14 @@ class Renderer:
 
         # Miscellaneous Data
         misc_data = [
+            f"Name: {self.game.player.name}",
+            f"Gender: {getattr(self.game.player, 'gender', 'Unknown')}",
+            f"Sex: {getattr(self.game.player, 'sex', 'Unknown')}",
+            f"Race: {getattr(self.game.player, 'race', 'Unknown')}",
             f"HP: {self.game.player.health}/{self.game.player.max_health}",
             f"PP: {self.game.player.psi}/{self.game.player.max_psi}",
             f"Speed: {self.game.player.speed}",
             f"Money: {self.game.player.money} gold",
-            f"Deity: {self.game.player.deity}",
-            f"Birth: {self.game.player.birth}",
-            f"Month: {self.game.player.month}",
-            f"Day: {self.game.player.day}",
-            f"Age: {self.game.player.age} years",
         ]
 
         # Equipment Data

--- a/pRoguelike.py
+++ b/pRoguelike.py
@@ -152,6 +152,10 @@ def main(stdscr, char_data):
         if hasattr(game.player, stat):
             setattr(game.player, stat, value)
 
+    # Recalculate derived attributes based on stats
+    game.player.max_health = 50 + game.player.constitution * 5
+    game.player.health = game.player.max_health
+
     while True:
         if game.character_stats_mode:
             game.renderer.draw_character_stats_screen(stdscr)


### PR DESCRIPTION
## Summary
- show name, gender, sex and race on the `@` stats screen
- remove unused deity and birth info from the stats screen
- use dexterity and constitution in combat rolls
- factor constitution into the defense stat
- update player health based on constitution

## Testing
- `python -m py_compile pRoguelike.py classes/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684043c8b4d8832bbb15357b253bb2cd