### PR TITLE
Add race data and update character creation

### DIFF
--- a/classes/entity.py
+++ b/classes/entity.py
@@ -52,6 +52,9 @@ class Entity:
         self.month = "Unknown"
         self.day = "Unknown"
         self.age = 0
+        self.gender = ""
+        self.sex = ""
+        self.race = ""
     
     @property
     def damage(self):

--- a/classes/race_loader.py
+++ b/classes/race_loader.py
@@ -1,0 +1,20 @@
+import json
+import os
+
+class Race:
+    def __init__(self, name, bonuses):
+        self.name = name
+        self.bonuses = bonuses
+
+
+def load_races():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    races_path = os.path.join(script_dir, '..', 'data', 'races.json')
+    with open(races_path, 'r') as file:
+        race_data = json.load(file)
+
+    races = [Race(r['name'], r.get('bonuses', {})) for r in race_data]
+    return races
+
+
+all_races = load_races()

--- a/data/races.json
+++ b/data/races.json
@@ -1,0 +1,51 @@
+[
+  {
+    "name": "Human",
+    "bonuses": {
+      "strength": 1,
+      "dexterity": 1,
+      "constitution": 1,
+      "intelligence": 1,
+      "willpower": 1,
+      "charisma": 1,
+      "appearance": 1,
+      "perception": 1
+    }
+  },
+  {
+    "name": "Elf",
+    "bonuses": {
+      "dexterity": 2,
+      "perception": 2,
+      "appearance": 1
+    }
+  },
+  {
+    "name": "Dwarf",
+    "bonuses": {
+      "constitution": 2,
+      "willpower": 1
+    }
+  },
+  {
+    "name": "Halfling",
+    "bonuses": {
+      "dexterity": 2,
+      "charisma": 1
+    }
+  },
+  {
+    "name": "Orc",
+    "bonuses": {
+      "strength": 2,
+      "constitution": 1
+    }
+  },
+  {
+    "name": "Gnome",
+    "bonuses": {
+      "intelligence": 2,
+      "dexterity": 1
+    }
+  }
+]

--- a/pRoguelike.py
+++ b/pRoguelike.py
@@ -13,6 +13,7 @@ sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 
 from classes.game import Game
 from classes.item import Equipment
+from classes.race_loader import all_races
 from curses import KEY_NPAGE, KEY_PPAGE
 
 def character_creation_cli():
@@ -20,8 +21,30 @@ def character_creation_cli():
     print("=== Character Creation ===")
     name = input("Name: ")
     gender = input("Gender: ")
-    sex = input("Sex: ")
-    race = input("Race: ")
+    # Choose sex
+    sex_options = ["male", "female", "other"]
+    while True:
+        print("Choose Sex:")
+        for idx, opt in enumerate(sex_options, 1):
+            print(f"  {idx}) {opt.title()}")
+        choice = input("Sex selection: ").strip()
+        if choice.isdigit() and 1 <= int(choice) <= len(sex_options):
+            sex = sex_options[int(choice) - 1]
+            break
+        else:
+            print("Invalid choice. Try again.")
+
+    # Choose race from data file
+    while True:
+        print("Choose Race:")
+        for idx, r in enumerate(all_races, 1):
+            print(f"  {idx}) {r.name}")
+        r_choice = input("Race selection: ").strip()
+        if r_choice.isdigit() and 1 <= int(r_choice) <= len(all_races):
+            race = all_races[int(r_choice) - 1]
+            break
+        else:
+            print("Invalid choice. Try again.")
 
     attributes = [
         "strength",
@@ -69,11 +92,15 @@ def character_creation_cli():
         if remaining:
             print(f"{remaining} unspent points will be ignored.")
 
+    # Apply race bonuses to stats
+    for attr, bonus in race.bonuses.items():
+        stats[attr] = stats.get(attr, 0) + bonus
+
     return {
         "name": name,
         "gender": gender,
         "sex": sex,
-        "race": race,
+        "race": race.name,
         "stats": stats,
     }
 


### PR DESCRIPTION
## Summary
- load race info from new `races.json`
- add a helper loader module to parse races
- store gender/sex/race on entities
- enhance CLI creation to choose sex and race and apply bonuses

## Testing
- `python -m py_compile pRoguelike.py classes/*.py`
- `python - <<'EOF'
from pRoguelike import character_creation_cli
import sys
from unittest import mock
inputs=['Hero','Nonbinary','3','1','r','']
with mock.patch('builtins.input', side_effect=lambda _: inputs.pop(0)):
    data=character_creation_cli()
print(data)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684045ba3c18832ba80d36d24c415d01