### PR TITLE
Improve stat rolling display and balance races

### DIFF
--- a/data/races.json
+++ b/data/races.json
@@ -2,14 +2,14 @@
   {
     "name": "Human",
     "bonuses": {
-      "strength": 1,
-      "dexterity": 1,
-      "constitution": 1,
-      "intelligence": 1,
-      "willpower": 1,
-      "charisma": 1,
-      "appearance": 1,
-      "perception": 1
+      "strength": 0,
+      "dexterity": 0,
+      "constitution": 0,
+      "intelligence": 0,
+      "willpower": 0,
+      "charisma": 0,
+      "appearance": 0,
+      "perception": 0
     }
   },
   {
@@ -17,35 +17,45 @@
     "bonuses": {
       "dexterity": 2,
       "perception": 2,
-      "appearance": 1
+      "appearance": 1,
+      "constitution": -2,
+      "strength": -1
     }
   },
   {
     "name": "Dwarf",
     "bonuses": {
       "constitution": 2,
-      "willpower": 1
+      "willpower": 1,
+      "charisma": -1,
+      "dexterity": -1
     }
   },
   {
     "name": "Halfling",
     "bonuses": {
       "dexterity": 2,
-      "charisma": 1
+      "charisma": 1,
+      "strength": -1,
+      "constitution": -1
     }
   },
   {
     "name": "Orc",
     "bonuses": {
       "strength": 2,
-      "constitution": 1
+      "constitution": 1,
+      "charisma": -2,
+      "intelligence": -1
     }
   },
   {
     "name": "Gnome",
     "bonuses": {
       "intelligence": 2,
-      "dexterity": 1
+      "dexterity": 1,
+      "strength": -1,
+      "constitution": -1
     }
   }
 ]

--- a/pRoguelike.py
+++ b/pRoguelike.py
@@ -125,10 +125,17 @@ def character_creation_cli():
     if method.startswith("r"):
         while True:
             clear_screen()
-            stats = {attr: random.randint(1, 20) for attr in attributes}
-            print("Rolled stats:")
+            base_stats = {attr: random.randint(1, 20) for attr in attributes}
+            stats = {
+                attr: base_stats[attr] + race.bonuses.get(attr, 0)
+                for attr in attributes
+            }
+            print("Rolled stats (base + racial bonus = total):")
             for attr in attributes:
-                print(f"  {attr.title()}: {stats[attr]}")
+                base = base_stats[attr]
+                bonus = race.bonuses.get(attr, 0)
+                total = stats[attr]
+                print(f"  {attr.title():<12}: {base:2d} + {bonus:+2d} = {total:2d}")
             print("Press 'r' to reroll or any other key to accept")
             choice = get_single_key().lower()
             if choice != "r":
@@ -138,9 +145,9 @@ def character_creation_cli():
         stats = {attr: 10 for attr in attributes}
         stats = wrapper(point_buy_curses, stats, 20)
 
-    # Apply race bonuses to stats
-    for attr, bonus in race.bonuses.items():
-        stats[attr] = stats.get(attr, 0) + bonus
+        # Apply race bonuses to stats after point buy
+        for attr, bonus in race.bonuses.items():
+            stats[attr] = stats.get(attr, 0) + bonus
 
     return {
         "name": name,


### PR DESCRIPTION
## Summary
- show detailed stat rolls with racial bonuses
- rebalance races with positive and negative modifiers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684053ed9df8832bb821376c50434184