### PR TITLE
Show seen items through fog

### DIFF
--- a/classes/game.py
+++ b/classes/game.py
@@ -424,6 +424,7 @@ class Game:
             item, _ = inventory_items[index]
             self.player.remove_item(item)
             item.x, item.y = self.player.x, self.player.y
+            item.seen = True  # Player is aware of dropped items immediately
             self.items.append(item)
             self.messages.append(f"You dropped {item.name}.")
             self.drop_mode = False
@@ -437,6 +438,7 @@ class Game:
             item, _ = inventory_items[index]
             self.player.remove_item(item)
             item.x, item.y = self.player.x, self.player.y
+            item.seen = True  # Player is aware of dropped items immediately
             self.items.append(item)
             self.messages.append(f"You dropped {item.name}.")
             self.drop_mode = False
@@ -799,6 +801,13 @@ class Game:
 
                 self.visible[y][x] = True
                 self.explored[y][x] = True
+
+        # Mark any items within the current field of view as seen so they remain
+        # visible on explored tiles even after they leave the player's sight.
+        for item in self.items:
+            if 0 <= item.y < self.height and 0 <= item.x < self.width:
+                if self.visible[item.y][item.x]:
+                    item.seen = True
     
     def open_equipment_screen(self):
         self.equipment_mode = True

--- a/classes/item.py
+++ b/classes/item.py
@@ -6,6 +6,10 @@ class Item:
         self.x = None
         self.y = None
         self.quantity = 1
+        # Track whether the player has seen this item on the ground. Items should
+        # only be visible outside the current field of view after they have been
+        # discovered once.
+        self.seen = False
 
     def __eq__(self, other):
         if isinstance(other, Item):

--- a/classes/renderer.py
+++ b/classes/renderer.py
@@ -51,9 +51,17 @@ class Renderer:
                     stdscr.addch(y, x, cell, curses.color_pair(1) | attr)  # Default
 
         for item in self.game.items:
-            if item.y < dungeon_height and self.game.visible[item.y][item.x]:
+            if item.y < dungeon_height and (
+                self.game.visible[item.y][item.x]
+                or (item.seen and self.game.explored[item.y][item.x])
+            ):
                 icon = self._icon_for(item)
-                stdscr.addch(item.y, item.x, icon, curses.color_pair(4))  # Items
+                attr = (
+                    curses.A_NORMAL
+                    if self.game.visible[item.y][item.x]
+                    else curses.A_DIM
+                )
+                stdscr.addch(item.y, item.x, icon, curses.color_pair(4) | attr)
 
         for enemy in self.game.enemies:
             if enemy.y < dungeon_height and self.game.visible[enemy.y][enemy.x]:


### PR DESCRIPTION
## Summary
- keep memory of previously seen items
- mark dropped items as seen immediately
- render seen items in dim color even if not in current FOV

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68407000c668832ba82f8298a613ec27