### PR TITLE
Add item info screen and compare equipped

### DIFF
--- a/classes/game.py
+++ b/classes/game.py
@@ -71,6 +71,8 @@ class Game:
         self.walk_speed = 5  # milliseconds between auto-move steps
         self.help_mode = False
         self.speed_input = ""
+        self.item_info_mode = False
+        self.item_info_item = None
 
     def open_character_stats_screen(self):
         self.character_stats_mode = True
@@ -168,7 +170,9 @@ class Game:
         return defeated
 
     def handle_input(self, key):
-        if self.inventory_mode:
+        if self.item_info_mode:
+            self.handle_item_info_input(key)
+        elif self.inventory_mode:
             self.input_handler.handle_inventory_input(key)
         elif self.backpack_mode:
             self.handle_backpack_input(key)
@@ -220,6 +224,9 @@ class Game:
         elif 97 <= key <= 122:  # a-z
             self.drop_backpack_item(chr(key))
 
+    def handle_item_info_input(self, key):
+        self.input_handler.handle_item_info_input(key)
+
     def draw(self, stdscr):
         self.renderer.draw(stdscr)
 
@@ -234,6 +241,9 @@ class Game:
 
     def draw_drop_interface(self, stdscr):
         self.renderer.draw_drop_interface(stdscr)
+
+    def draw_item_info(self, stdscr):
+        self.renderer.draw_item_info(stdscr)
 
     def generate_level(self):
         self.map, self.rooms, self.stairs_up_x, self.stairs_up_y, self.stairs_x, self.stairs_y = self.map_generator.generate_level(self.player)

--- a/classes/input_handler.py
+++ b/classes/input_handler.py
@@ -150,6 +150,14 @@ class InputHandler:
                     self.game.messages.append(f"{item.name} cannot be equipped.")
             else:
                 self.game.messages.append("Invalid item.")
+        elif 65 <= key <= 90:  # A-Z for item info
+            index = key - ord('A') + self.game.inventory_page * self.game.items_per_page
+            if 0 <= index < len(inventory_items):
+                item, _ = inventory_items[index]
+                self.game.item_info_item = item
+                self.game.item_info_mode = True
+            else:
+                self.game.messages.append("Invalid item.")
 
     def handle_character_screen_input(self, key):
         if key == 27:  # ESC key
@@ -213,6 +221,11 @@ class InputHandler:
     def handle_help_input(self, key):
         if key in (27, ord('q')):
             self.game.help_mode = False
+
+    def handle_item_info_input(self, key):
+        if key == 27:  # ESC key
+            self.game.item_info_mode = False
+            self.game.item_info_item = None
 
     def handle_debug_input(self, key):
         # If the menu isn't open yet, hitting '!' will open it

--- a/classes/renderer.py
+++ b/classes/renderer.py
@@ -206,6 +206,68 @@ class Renderer:
 
         stdscr.refresh()
 
+    def draw_item_info(self, stdscr):
+        stdscr.clear()
+        height, width = stdscr.getmaxyx()
+
+        item = self.game.item_info_item
+        stdscr.addstr(0, 0, "Item Details (press escape to return)"[:width-1])
+
+        if not item:
+            stdscr.refresh()
+            return
+
+        lines = []
+        lines.append(f"Name: {item.name}")
+
+        if isinstance(item, Equipment):
+            lines.append(f"Slot: {item.slot}")
+            lines.append(f"Body: {item.body_part}")
+            if item.damage:
+                if isinstance(item.damage, dict):
+                    dmg = f"{item.damage.get('min', 0)}-{item.damage.get('max', 0)}"
+                else:
+                    dmg = str(item.damage)
+                lines.append(f"Damage: {dmg}")
+            if item.ac is not None:
+                lines.append(f"AC: {item.ac}")
+            if item.accuracy_bonus:
+                lines.append(f"Accuracy Bonus: {item.accuracy_bonus}")
+            lines.append(f"Stat Bonus: {item.stat_boost}")
+
+            equipped = None
+            for slot in self.game.player.equipment.values():
+                if slot['name'] == item.slot:
+                    equipped = slot['item']
+                    break
+            if equipped:
+                lines.append("")
+                lines.append(f"Equipped: {equipped.name}")
+                if equipped.damage or item.damage:
+                    if equipped.damage:
+                        eqd = f"{equipped.damage.get('min',0)}-{equipped.damage.get('max',0)}" if isinstance(equipped.damage, dict) else str(equipped.damage)
+                    else:
+                        eqd = "-"
+                    dmg = f"{item.damage.get('min',0)}-{item.damage.get('max',0)}" if isinstance(item.damage, dict) else str(item.damage)
+                    lines.append(f"Damage: {eqd} -> {dmg}")
+                if equipped.ac is not None or item.ac is not None:
+                    eqac = equipped.ac if equipped.ac is not None else '-'
+                    lines.append(f"AC: {eqac} -> {item.ac if item.ac is not None else '-'}")
+                if equipped.accuracy_bonus or item.accuracy_bonus:
+                    lines.append(f"Accuracy: {equipped.accuracy_bonus} -> {item.accuracy_bonus}")
+                lines.append(f"Stat Bonus: {equipped.stat_boost} -> {item.stat_boost}")
+        else:
+            if item.duration:
+                lines.append(f"Duration: {item.duration}")
+            lines.append("Consumable item")
+
+        for i, line in enumerate(lines, start=2):
+            if i >= height:
+                break
+            stdscr.addstr(i, 0, line[:width-1])
+
+        stdscr.refresh()
+
     def draw_equipment_screen(self, stdscr):
         stdscr.clear()
         height, width = stdscr.getmaxyx()

--- a/pRoguelike.py
+++ b/pRoguelike.py
@@ -262,6 +262,8 @@ def main(stdscr, char_data):
     while True:
         if game.character_stats_mode:
             game.renderer.draw_character_stats_screen(stdscr)
+        elif game.item_info_mode:
+            game.renderer.draw_item_info(stdscr)
         elif game.inventory_mode:
             game.renderer.draw_inventory(stdscr)
         elif game.backpack_mode:
@@ -283,6 +285,9 @@ def main(stdscr, char_data):
         key = stdscr.getch()
         if game.debug_mode and key == 27:  # ESC key
             game.debug_mode = False
+        elif game.item_info_mode:
+            if game.handle_input(key):
+                break
         elif game.inventory_mode:
             if key in (ord('+'), ord('.'), KEY_NPAGE):  # Next page (+ key, . key, or PgDn)
                 game.inventory_page = min(game.inventory_page + 1, (len(game.player.inventory) - 1) // game.items_per_page)


### PR DESCRIPTION
## Summary
- allow pressing SHIFT+letter in inventory to inspect an item
- show an info screen with equipment comparison
- integrate new screen into main loop

## Testing
- `python -m py_compile pRoguelike.py classes/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68407073d5d0832b8cd4a1b53dcdd0a0