### PR TITLE
Show item stats in inventory

### DIFF
--- a/classes/entity.py
+++ b/classes/entity.py
@@ -174,6 +174,7 @@ class Entity:
                 damage=dagger_base.damage,
                 ac=dagger_base.ac,
                 accuracy_bonus=dagger_base.accuracy_bonus,
+                weight=dagger_base.weight,
             )
             self.equip(dagger, 'a')  # 'a' is the weapon slot
 
@@ -185,6 +186,7 @@ class Entity:
                 cloth.power,
                 damage=robe_base.damage,
                 ac=robe_base.ac,
+                weight=robe_base.weight,
             )
             self.equip(robe, 'f')  # 'f' is the armor slot
 

--- a/classes/game.py
+++ b/classes/game.py
@@ -71,8 +71,6 @@ class Game:
         self.walk_speed = 5  # milliseconds between auto-move steps
         self.help_mode = False
         self.speed_input = ""
-        self.item_info_mode = False
-        self.item_info_item = None
 
     def open_character_stats_screen(self):
         self.character_stats_mode = True
@@ -106,9 +104,16 @@ class Game:
                 damage=item_template.damage,
                 ac=item_template.ac,
                 accuracy_bonus=item_template.accuracy_bonus,
+                weight=item_template.weight,
             )
         else:
-            return Item(item_template.name, item_template.effect)
+            return Item(
+                item_template.name,
+                item_template.effect,
+                value=getattr(item_template, "value", None),
+                weight=item_template.weight,
+                effect_type=getattr(item_template, "effect_type", None),
+            )
 
     def create_specific_item(self, category):
         if category == 'potion':
@@ -134,9 +139,16 @@ class Game:
                 damage=template.damage,
                 ac=template.ac,
                 accuracy_bonus=template.accuracy_bonus,
+                weight=template.weight,
             )
         else:
-            return Item(template.name, template.effect)
+            return Item(
+                template.name,
+                template.effect,
+                value=getattr(template, "value", None),
+                weight=template.weight,
+                effect_type=getattr(template, "effect_type", None),
+            )
 
     def map_current_level(self):
         for y in range(self.height):
@@ -170,9 +182,7 @@ class Game:
         return defeated
 
     def handle_input(self, key):
-        if self.item_info_mode:
-            self.handle_item_info_input(key)
-        elif self.inventory_mode:
+        if self.inventory_mode:
             self.input_handler.handle_inventory_input(key)
         elif self.backpack_mode:
             self.handle_backpack_input(key)
@@ -224,9 +234,6 @@ class Game:
         elif 97 <= key <= 122:  # a-z
             self.drop_backpack_item(chr(key))
 
-    def handle_item_info_input(self, key):
-        self.input_handler.handle_item_info_input(key)
-
     def draw(self, stdscr):
         self.renderer.draw(stdscr)
 
@@ -241,9 +248,6 @@ class Game:
 
     def draw_drop_interface(self, stdscr):
         self.renderer.draw_drop_interface(stdscr)
-
-    def draw_item_info(self, stdscr):
-        self.renderer.draw_item_info(stdscr)
 
     def generate_level(self):
         self.map, self.rooms, self.stairs_up_x, self.stairs_up_y, self.stairs_x, self.stairs_y = self.map_generator.generate_level(self.player)
@@ -266,7 +270,15 @@ class Game:
             defense = int((random.randint(0, 3) + self.dungeon_level // 2) * difficulty_factor)
             enemy = Entity(x, y, 'E', f"Enemy Lv{self.dungeon_level}", health, damage, defense)
             if random.random() < 0.3:
-                enemy.add_item(Item("Health Potion", lambda e: setattr(e, 'health', min(e.max_health, e.health + 20))))
+                enemy.add_item(
+                    Item(
+                        "Health Potion",
+                        lambda e: setattr(e, 'health', min(e.max_health, e.health + 20)),
+                        value=20,
+                        weight=1,
+                        effect_type='heal',
+                    )
+                )
             self.enemies.append(enemy)
 
     def get_random_floor(self):

--- a/classes/input_handler.py
+++ b/classes/input_handler.py
@@ -150,14 +150,6 @@ class InputHandler:
                     self.game.messages.append(f"{item.name} cannot be equipped.")
             else:
                 self.game.messages.append("Invalid item.")
-        elif 65 <= key <= 90:  # A-Z for item info
-            index = key - ord('A') + self.game.inventory_page * self.game.items_per_page
-            if 0 <= index < len(inventory_items):
-                item, _ = inventory_items[index]
-                self.game.item_info_item = item
-                self.game.item_info_mode = True
-            else:
-                self.game.messages.append("Invalid item.")
 
     def handle_character_screen_input(self, key):
         if key == 27:  # ESC key
@@ -222,10 +214,6 @@ class InputHandler:
         if key in (27, ord('q')):
             self.game.help_mode = False
 
-    def handle_item_info_input(self, key):
-        if key == 27:  # ESC key
-            self.game.item_info_mode = False
-            self.game.item_info_item = None
 
     def handle_debug_input(self, key):
         # If the menu isn't open yet, hitting '!' will open it

--- a/classes/item.py
+++ b/classes/item.py
@@ -1,8 +1,11 @@
 class Item:
-    def __init__(self, name, effect, duration=None):
+    def __init__(self, name, effect, duration=None, value=None, weight=1, effect_type=None):
         self.name = name
         self.effect = effect
         self.duration = duration
+        self.value = value
+        self.weight = weight
+        self.effect_type = effect_type
         self.x = None
         self.y = None
         self.quantity = 1
@@ -20,8 +23,8 @@ class Item:
         return hash(self.name)
 
 class Equipment(Item):
-    def __init__(self, name, slot, body_part, stat_boost, damage=None, ac=None, accuracy_bonus=0):
-        super().__init__(name, None)
+    def __init__(self, name, slot, body_part, stat_boost, damage=None, ac=None, accuracy_bonus=0, weight=1):
+        super().__init__(name, None, None, None, weight)
         self.slot = slot
         self.body_part = body_part
         self.damage = damage

--- a/classes/item_loader.py
+++ b/classes/item_loader.py
@@ -22,7 +22,14 @@ def load_items():
     consumables = []
     for item_data in consumable_data:
         effect = create_effect(item_data['effect'], item_data['value'])
-        item = Item(item_data['name'], effect, item_data.get('duration', None))
+        item = Item(
+            item_data['name'],
+            effect,
+            item_data.get('duration', None),
+            value=item_data.get('value'),
+            weight=item_data.get('weight', 1),
+            effect_type=item_data.get('effect'),
+        )
         consumables.append(item)
 
     materials = [Material(m['name'], m['power']) for m in material_data]
@@ -44,6 +51,7 @@ def load_items():
                 damage=item_data.get('damage'),
                 ac=item_data.get('ac'),
                 accuracy_bonus=accuracy,
+                weight=item_data.get('weight', 1),
             )
             equipment.append(item)
 

--- a/classes/renderer.py
+++ b/classes/renderer.py
@@ -27,6 +27,56 @@ class Renderer:
             return ITEM_ICONS.get(item.slot, '?')
         return '!'
 
+    def _format_item_stats(self, item):
+        info = []
+        if isinstance(item, Equipment):
+            equipped = None
+            for slot_key, slot in self.game.player.equipment.items():
+                if slot['name'] == item.slot:
+                    equipped = slot['item']
+                    break
+            if item.damage is not None:
+                dmg = (
+                    f"{item.damage.get('min',0)}-{item.damage.get('max',0)}"
+                    if isinstance(item.damage, dict)
+                    else str(item.damage)
+                )
+                if equipped and equipped.damage is not None:
+                    eqd = (
+                        f"{equipped.damage.get('min',0)}-{equipped.damage.get('max',0)}"
+                        if isinstance(equipped.damage, dict)
+                        else str(equipped.damage)
+                    )
+                    info.append(f"DMG {eqd}->{dmg}")
+                else:
+                    info.append(f"DMG {dmg}")
+            if item.ac is not None:
+                if equipped and equipped.ac is not None:
+                    info.append(f"AC {equipped.ac}->{item.ac}")
+                else:
+                    info.append(f"AC {item.ac}")
+            if item.accuracy_bonus:
+                if equipped and equipped.accuracy_bonus:
+                    info.append(f"ACC {equipped.accuracy_bonus}->{item.accuracy_bonus}")
+                else:
+                    info.append(f"ACC {item.accuracy_bonus}")
+            if item.stat_boost:
+                if equipped and equipped.stat_boost:
+                    info.append(f"STAT {equipped.stat_boost}->{item.stat_boost}")
+                else:
+                    info.append(f"STAT {item.stat_boost}")
+            info.append(f"WT {item.weight}")
+        else:
+            if getattr(item, 'effect_type', None) == 'heal':
+                info.append(f"Heal {item.value}")
+            elif getattr(item, 'effect_type', None) == 'restore_mana':
+                info.append(f"Mana {item.value}")
+            elif getattr(item, 'effect_type', '').startswith('boost_'):
+                stat = item.effect_type.split('_', 1)[1].title()
+                info.append(f"+{item.value} {stat}")
+            info.append(f"WT {item.weight}")
+        return ' '.join(info)
+
     def draw(self, stdscr):
         stdscr.clear()
         height, width = stdscr.getmaxyx()
@@ -94,7 +144,8 @@ class Renderer:
 
         for i, (item, count) in enumerate(inventory_items[start_index:end_index], start=0):
             key = chr(97 + i)  # a-z
-            item_str = f"{key}) {item.name} [{count}]"
+            info = self._format_item_stats(item)
+            item_str = f"{key}) {item.name} [{count}] {info}"
             stdscr.addstr(i + 2, 0, item_str[:width-1])
 
         total_pages = max(1, (len(inventory_items) - 1) // self.game.items_per_page + 1)
@@ -214,67 +265,6 @@ class Renderer:
 
         stdscr.refresh()
 
-    def draw_item_info(self, stdscr):
-        stdscr.clear()
-        height, width = stdscr.getmaxyx()
-
-        item = self.game.item_info_item
-        stdscr.addstr(0, 0, "Item Details (press escape to return)"[:width-1])
-
-        if not item:
-            stdscr.refresh()
-            return
-
-        lines = []
-        lines.append(f"Name: {item.name}")
-
-        if isinstance(item, Equipment):
-            lines.append(f"Slot: {item.slot}")
-            lines.append(f"Body: {item.body_part}")
-            if item.damage:
-                if isinstance(item.damage, dict):
-                    dmg = f"{item.damage.get('min', 0)}-{item.damage.get('max', 0)}"
-                else:
-                    dmg = str(item.damage)
-                lines.append(f"Damage: {dmg}")
-            if item.ac is not None:
-                lines.append(f"AC: {item.ac}")
-            if item.accuracy_bonus:
-                lines.append(f"Accuracy Bonus: {item.accuracy_bonus}")
-            lines.append(f"Stat Bonus: {item.stat_boost}")
-
-            equipped = None
-            for slot in self.game.player.equipment.values():
-                if slot['name'] == item.slot:
-                    equipped = slot['item']
-                    break
-            if equipped:
-                lines.append("")
-                lines.append(f"Equipped: {equipped.name}")
-                if equipped.damage or item.damage:
-                    if equipped.damage:
-                        eqd = f"{equipped.damage.get('min',0)}-{equipped.damage.get('max',0)}" if isinstance(equipped.damage, dict) else str(equipped.damage)
-                    else:
-                        eqd = "-"
-                    dmg = f"{item.damage.get('min',0)}-{item.damage.get('max',0)}" if isinstance(item.damage, dict) else str(item.damage)
-                    lines.append(f"Damage: {eqd} -> {dmg}")
-                if equipped.ac is not None or item.ac is not None:
-                    eqac = equipped.ac if equipped.ac is not None else '-'
-                    lines.append(f"AC: {eqac} -> {item.ac if item.ac is not None else '-'}")
-                if equipped.accuracy_bonus or item.accuracy_bonus:
-                    lines.append(f"Accuracy: {equipped.accuracy_bonus} -> {item.accuracy_bonus}")
-                lines.append(f"Stat Bonus: {equipped.stat_boost} -> {item.stat_boost}")
-        else:
-            if item.duration:
-                lines.append(f"Duration: {item.duration}")
-            lines.append("Consumable item")
-
-        for i, line in enumerate(lines, start=2):
-            if i >= height:
-                break
-            stdscr.addstr(i, 0, line[:width-1])
-
-        stdscr.refresh()
 
     def draw_equipment_screen(self, stdscr):
         stdscr.clear()

--- a/pRoguelike.py
+++ b/pRoguelike.py
@@ -262,8 +262,6 @@ def main(stdscr, char_data):
     while True:
         if game.character_stats_mode:
             game.renderer.draw_character_stats_screen(stdscr)
-        elif game.item_info_mode:
-            game.renderer.draw_item_info(stdscr)
         elif game.inventory_mode:
             game.renderer.draw_inventory(stdscr)
         elif game.backpack_mode:
@@ -285,9 +283,6 @@ def main(stdscr, char_data):
         key = stdscr.getch()
         if game.debug_mode and key == 27:  # ESC key
             game.debug_mode = False
-        elif game.item_info_mode:
-            if game.handle_input(key):
-                break
         elif game.inventory_mode:
             if key in (ord('+'), ord('.'), KEY_NPAGE):  # Next page (+ key, . key, or PgDn)
                 game.inventory_page = min(game.inventory_page + 1, (len(game.player.inventory) - 1) // game.items_per_page)


### PR DESCRIPTION
## Summary
- add weight and value info to items
- load weight/value in item loader
- create items with proper weight info
- remove Shift+letter detail view and item info mode
- print item combat stats and comparisons in inventory

## Testing
- `python -m py_compile pRoguelike.py classes/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684073811f48832ba7ae971c54ea485c