### PR TITLE
Revamp combat scaling with logistic hit chances

### DIFF
--- a/classes/combat_system.py
+++ b/classes/combat_system.py
@@ -1,4 +1,5 @@
 import random
+import math
 
 class CombatSystem:
     @staticmethod
@@ -9,19 +10,20 @@ class CombatSystem:
             None,
         )
         accuracy_bonus = weapon.accuracy_bonus if weapon else 0
-        attack_bonus = max(0, (attacker.strength - 10) // 2)
-        attack_bonus += max(0, (attacker.dexterity - 10) // 2)
-        attack_roll = random.randint(1, 20) + attack_bonus + accuracy_bonus
 
-        defense_bonus = max(0, (defender.dexterity - 10) // 2)
-        defense_bonus += max(0, (defender.constitution - 10) // 2)
-        defense_value = 10 + defender.defense + defense_bonus
+        # Calculate attack and defense scores
+        attack_score = attacker.damage + accuracy_bonus
+        defense_score = defender.defense
 
-        if attack_roll >= defense_value:
-            damage = max(1, base_damage + random.randint(-2, 2))
+        # Logistic function converts score difference into win probability
+        diff = attack_score - defense_score
+        hit_chance = 1 / (1 + math.exp(-diff / 5))
+
+        if random.random() < hit_chance:
+            damage = max(1, int(base_damage + random.randint(-2, 2)))
             defender.health -= damage
             messages.append(f"{attacker.name} hits {defender.name} for {damage} damage.")
-            
+
             if defender.health <= 0:
                 messages.append(f"{defender.name} is defeated!")
                 return True  # Enemy defeated

--- a/classes/entity.py
+++ b/classes/entity.py
@@ -58,21 +58,34 @@ class Entity:
     
     @property
     def damage(self):
-        weapon = next((slot['item'] for slot in self.equipment.values() if slot['name'] in ['weapon', 'missile weapon']), None)
+        """Total damage output including stat and level bonuses."""
+        weapon = next(
+            (slot['item'] for slot in self.equipment.values() if slot['name'] in ['weapon', 'missile weapon']),
+            None,
+        )
         weapon_bonus = weapon.damage_bonus if weapon else 0
-        strength_bonus = max(0, (self.strength - 10) // 2)  # +1 for every 2 points above 10
-        return self.base_damage + weapon_bonus + strength_bonus
+
+        # Every point of strength increases damage. Levels give a small bonus
+        strength_bonus = self.strength * 0.5
+        level_bonus = self.level * 0.5
+
+        return self.base_damage + weapon_bonus + strength_bonus + level_bonus
 
     @property
     def defense(self):
+        """Total defense score including stat and level bonuses."""
         armor_bonus = sum(
             slot['item'].defense_bonus
             for slot in self.equipment.values()
             if slot['item']
         )
-        dexterity_bonus = max(0, (self.dexterity - 10) // 2)  # +1 for every 2 points above 10
-        constitution_bonus = max(0, (self.constitution - 10) // 2)
-        return self.base_defense + armor_bonus + dexterity_bonus + constitution_bonus
+
+        # Every point of dexterity/constitution increases defense
+        dexterity_bonus = self.dexterity * 0.3
+        constitution_bonus = self.constitution * 0.2
+        level_bonus = self.level * 0.5
+
+        return self.base_defense + armor_bonus + dexterity_bonus + constitution_bonus + level_bonus
 
     def equip(self, item, slot_key):
         slot = self.equipment[slot_key]
@@ -142,8 +155,6 @@ class Entity:
         self.xp_to_next_level = int(self.xp_to_next_level * 1.5)
         self.max_health += 10
         self.health = self.max_health
-        self.base_damage += 2
-        self.base_defense += 1
         
         # Increase stats randomly
         stats = ['strength', 'dexterity', 'constitution', 'intelligence', 'willpower', 'charisma', 'appearance', 'perception']

--- a/classes/game.py
+++ b/classes/game.py
@@ -30,7 +30,8 @@ class Game:
         # Sync game dimensions with the actual map size generated
         self.height = self.map_generator.height
         self.width = self.map_generator.width
-        self.player = Entity(width // 2, height // 2, '@', "Player", 100, 10, 0)
+        # Player starts with no inherent damage or defense; stats and gear scale these
+        self.player = Entity(width // 2, height // 2, '@', "Player", 100, 0, 0)
         self.player.initialize_player()
         self.enemies = []
         self.inventory_page = 0
@@ -266,9 +267,18 @@ class Game:
             x, y = self.get_random_floor()
             difficulty_factor = min(2, 1 + (self.dungeon_level - 1) * 0.1)
             health = int((random.randint(20, 40) + self.dungeon_level * 5) * difficulty_factor)
-            damage = int((random.randint(5, 10) + self.dungeon_level) * difficulty_factor)
-            defense = int((random.randint(0, 3) + self.dungeon_level // 2) * difficulty_factor)
-            enemy = Entity(x, y, 'E', f"Enemy Lv{self.dungeon_level}", health, damage, defense)
+            base_damage = 0
+            base_defense = 0
+            enemy = Entity(x, y, 'E', f"Enemy Lv{self.dungeon_level}", health, base_damage, base_defense)
+
+            # Approximate attributes based on desired difficulty
+            raw_damage = int((random.randint(5, 10) + self.dungeon_level) * difficulty_factor)
+            raw_defense = int((random.randint(0, 3) + self.dungeon_level // 2) * difficulty_factor)
+
+            enemy.strength = raw_damage * 2
+            enemy.dexterity = max(1, raw_defense * 3)
+            enemy.constitution = max(1, raw_defense * 2)
+            enemy.level = self.dungeon_level
             if random.random() < 0.3:
                 enemy.add_item(
                     Item(


### PR DESCRIPTION
## Summary
- base offensive and defensive stats start at zero
- per-point bonuses for attributes scale damage and defense
- compute hit probability via logistic function in `CombatSystem`
- spawn monsters with attributes derived from dungeon level

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68407578a984832b81b65625cabe95ce