### PR TITLE
Round float stats to one decimal

### DIFF
--- a/classes/entity.py
+++ b/classes/entity.py
@@ -69,7 +69,8 @@ class Entity:
         strength_bonus = self.strength * 0.5
         level_bonus = self.level * 0.5
 
-        return self.base_damage + weapon_bonus + strength_bonus + level_bonus
+        total_damage = self.base_damage + weapon_bonus + strength_bonus + level_bonus
+        return round(total_damage, 1)
 
     @property
     def defense(self):
@@ -85,7 +86,14 @@ class Entity:
         constitution_bonus = self.constitution * 0.2
         level_bonus = self.level * 0.5
 
-        return self.base_defense + armor_bonus + dexterity_bonus + constitution_bonus + level_bonus
+        total_defense = (
+            self.base_defense
+            + armor_bonus
+            + dexterity_bonus
+            + constitution_bonus
+            + level_bonus
+        )
+        return round(total_defense, 1)
 
     def equip(self, item, slot_key):
         slot = self.equipment[slot_key]

--- a/classes/renderer.py
+++ b/classes/renderer.py
@@ -121,7 +121,11 @@ class Renderer:
             stdscr.addch(self.game.player.y, self.game.player.x, self.game.player.char, curses.color_pair(2))  # Player
 
         # Status bar
-        stdscr.addstr(height - 6, 0, f"Health: {self.game.player.health}/{self.game.player.max_health} | Damage: {self.game.player.damage} | Defense: {self.game.player.defense}")
+        stdscr.addstr(
+            height - 6,
+            0,
+            f"Health: {self.game.player.health}/{self.game.player.max_health} | Damage: {self.game.player.damage:.1f} | Defense: {self.game.player.defense:.1f}",
+        )
         stdscr.addstr(height - 5, 0, f"Level: {self.game.player.level} | XP: {self.game.player.xp}/{self.game.player.xp_to_next_level} | Dungeon Level: {self.game.dungeon_level}")
 
         # Messages
@@ -173,8 +177,8 @@ class Renderer:
             "",
             f"Base Damage: {self.game.player.base_damage}",
             f"Base Defense: {self.game.player.base_defense}",
-            f"Total Damage: {self.game.player.damage}",
-            f"Total Defense: {self.game.player.defense}",
+            f"Total Damage: {self.game.player.damage:.1f}",
+            f"Total Defense: {self.game.player.defense:.1f}",
             "",
             f"Money: {self.game.player.money} gold",
         ]

--- a/pRoguelike.py
+++ b/pRoguelike.py
@@ -212,7 +212,11 @@ def draw(stdscr, game):
     stdscr.addch(game.player.y, game.player.x, game.player.char)
 
     # Status bar
-    stdscr.addstr(height - 3, 0, f"Health: {game.player.health}/{game.player.max_health} | Damage: {game.player.damage} | Defense: {game.player.defense}")
+    stdscr.addstr(
+        height - 3,
+        0,
+        f"Health: {game.player.health}/{game.player.max_health} | Damage: {game.player.damage:.1f} | Defense: {game.player.defense:.1f}",
+    )
     stdscr.addstr(height - 2, 0, f"Level: {game.player.level} | XP: {game.player.xp}/{game.player.xp_to_next_level} | Dungeon Level: {game.dungeon_level}")
 
     # Inventory


### PR DESCRIPTION
## Summary
- round damage and defense calculations
- format combat stats with one decimal place in the UI

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68407871020c832b839b6867164f5530