### PR TITLE
Fix enemy turn processing after player attacks

### DIFF
--- a/classes/game.py
+++ b/classes/game.py
@@ -176,9 +176,14 @@ class Game:
 
                 if dropped_item:
                     self.items.append(dropped_item)
-                    self.messages.append(f"{defender.name} dropped a {dropped_item.name}!")
+                    self.messages.append(
+                        f"{defender.name} dropped a {dropped_item.name}!"
+                    )
             elif defender == self.player:
                 self.handle_player_death()
+
+        if attacker == self.player:
+            self.process_turn()
 
         return defeated
 
@@ -885,7 +890,6 @@ class Game:
 
         if enemy_at_position:
             self.combat(self.player, enemy_at_position)
-            self.process_turn()
         elif self.is_valid_move(new_x, new_y):
             self.player.x, self.player.y = new_x, new_y
             self.process_turn()


### PR DESCRIPTION
## Summary
- make enemies take their turn whenever the player attacks

## Testing
- `python -m py_compile classes/*.py pRoguelike.py`


------
https://chatgpt.com/codex/tasks/task_e_68407ca364d8832bb64580adab359354