### PR TITLE
Fix level generation limits and floor search

### DIFF
--- a/classes/game.py
+++ b/classes/game.py
@@ -87,7 +87,10 @@ class Game:
             # Reduce the number of items spawned by 50%
             num_items = max(1, (5 + self.dungeon_level) // 2)
         for _ in range(num_items):
-            x, y = self.get_random_floor()
+            pos = self.get_random_floor()
+            if not pos:
+                break
+            x, y = pos
             item = self.create_random_item()
             item.x, item.y = x, y
             self.items.append(item)
@@ -278,7 +281,10 @@ class Game:
 
     def spawn_enemies(self, num_enemies):
         for _ in range(num_enemies):
-            x, y = self.get_random_floor()
+            pos = self.get_random_floor()
+            if not pos:
+                break
+            x, y = pos
             difficulty_factor = min(2, 1 + (self.dungeon_level - 1) * 0.1)
             health = int((random.randint(20, 40) + self.dungeon_level * 5) * difficulty_factor)
             base_damage = 0
@@ -305,12 +311,19 @@ class Game:
                 )
             self.enemies.append(enemy)
 
-    def get_random_floor(self):
-        while True:
+    def get_random_floor(self, max_attempts=1000):
+        """Return coordinates of a random walkable tile or ``None`` if none are
+        available."""
+        for _ in range(max_attempts):
             x = random.randint(0, self.map_generator.width - 1)
             y = random.randint(0, self.map_generator.height - 1)
-            if self.map[y][x] == '.' and not any(e.x == x and e.y == y for e in self.enemies):
+            if (
+                self.map[y][x] == '.'
+                and (x, y) != (self.player.x, self.player.y)
+                and not any(e.x == x and e.y == y for e in self.enemies)
+            ):
                 return x, y
+        return None
 
     def is_valid_move(self, x, y):
         return 0 <= x < self.width and 0 <= y < self.height and self.map[y][x] in ['.', '>', '<']

--- a/classes/map_generator.py
+++ b/classes/map_generator.py
@@ -2,8 +2,13 @@ import random
 
 class MapGenerator:
     def __init__(self, height, width, screen_height, screen_width):
-        self.height = min(max(10, height), screen_height - 5)  # Ensure minimum height of 10 and max height of screen height minus 5
-        self.width = min(max(20, width), screen_width - 5)  # Ensure minimum width of 20 and max width of screen width minus 5
+        # Reserve six lines at the bottom of the screen for the UI.  Using
+        # ``screen_height - 6`` keeps the generated map fully visible.
+        self.height = min(max(10, height), screen_height - 6)
+
+        # Reserve a few columns on the right so the map never exceeds the
+        # available width.  ``max`` ensures a sensible minimum size.
+        self.width = min(max(20, width), screen_width - 5)
 
     def generate(self):
         # Existing map generation logic


### PR DESCRIPTION
## Summary
- ensure generated map height accounts for message log lines
- avoid infinite loops when spawning enemies and items by limiting floor search
- consider the player's position when picking random floor tiles

## Testing
- `python -m compileall -q`

------
https://chatgpt.com/codex/tasks/task_e_6840809b2868832b9e85a8e9d283bee7