### PR TITLE
Fix potion usage and add poison effect

### DIFF
--- a/classes/entity.py
+++ b/classes/entity.py
@@ -268,6 +268,11 @@ class Entity:
             return f"You restored {gained} mana."
         return "Your mana is already full."
 
+    def take_damage(self, amount):
+        """Inflict damage on the entity and report the loss."""
+        self.health = max(0, self.health - amount)
+        return f"You take {amount} damage."
+
     def equip_item(self, item):
         for slot_key, slot in self.equipment.items():
             if slot['name'] == item.slot:

--- a/classes/input_handler.py
+++ b/classes/input_handler.py
@@ -125,9 +125,9 @@ class InputHandler:
     def handle_inventory_input(self, key):
         """Handle key presses while the inventory screen is open.
 
-        Pressing the letter of an item will attempt to equip it. Page
-        navigation is handled with '+' and '-'.  Press ESC to leave the
-        inventory."""
+        Pressing the letter of an item will equip it if possible or use it
+        otherwise. Page navigation is handled with '+' and '-'.  Press ESC
+        to leave the inventory."""
 
         inventory_items = self.game.player.get_inventory_items()
         max_pages = (len(inventory_items) - 1) // self.game.items_per_page
@@ -147,7 +147,7 @@ class InputHandler:
                 if isinstance(item, Equipment):
                     self.game.equip_item(item)
                 else:
-                    self.game.messages.append(f"{item.name} cannot be equipped.")
+                    self.game.use_item(item)
             else:
                 self.game.messages.append("Invalid item.")
 

--- a/classes/item_loader.py
+++ b/classes/item_loader.py
@@ -86,6 +86,8 @@ def create_effect(effect_type, value):
         return lambda e: e.apply_temporary_boost('strength', value, 50)  # 50 turns duration
     elif effect_type == 'boost_dexterity':
         return lambda e: e.apply_temporary_boost('dexterity', value, 50)  # 50 turns duration
+    elif effect_type in ('poison', 'damage'):
+        return lambda e: e.take_damage(value)
     else:
         return lambda e: None  # Null effect if not recognized
 

--- a/data/items/consumables.json
+++ b/data/items/consumables.json
@@ -48,5 +48,10 @@
     "name": "Dexterity Draught",
     "effect": "boost_dexterity",
     "value": 3
+  },
+  {
+    "name": "Poison Potion",
+    "effect": "poison",
+    "value": 10
   }
 ]


### PR DESCRIPTION
## Summary
- allow using consumables directly from the inventory screen
- add `take_damage` helper to Entity
- support `poison`/`damage` effects when loading items
- include a new `Poison Potion` consumable

## Testing
- `python3 -m py_compile classes/*.py pRoguelike.py`

------
https://chatgpt.com/codex/tasks/task_e_684086aa95e0832b855e8259542259b2