### PR TITLE
Monster challenge rating integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ PRogue is a traditional roguelike game. This project is in its very early stages
 
 - Procedurally generated dungeons
 - Turn-based combat with random enemies and loot
+- Monsters are selected by dungeon level using their challenge rating
 - Diagonal movement using the number pad (1,3,7,9)
 - Auto-explore and walk-to-stairs commands
 - Inventory and equipment management screens

--- a/classes/combat_system.py
+++ b/classes/combat_system.py
@@ -39,14 +39,26 @@ class CombatSystem:
 
     def player_attack_enemy(self, player, enemy, messages):
         """Handle rewards when the player defeats an enemy."""
-
         messages.append(f"You defeated {enemy.name}!")
-        player.gain_xp(20 + enemy.level * 5)
 
-        # 5% chance to drop a random item
-        if random.random() < 0.05:
-            dropped_item = self.create_random_item()
-            dropped_item.x, dropped_item.y = enemy.x, enemy.y
-            return dropped_item
+        xp = getattr(enemy, 'xp_reward', 20 + enemy.level * 5)
+        player.gain_xp(xp)
+        messages.append(f"You gain {xp} XP.")
 
-        return None
+        gold = getattr(enemy, 'gold_reward', 0)
+        if gold:
+            player.money += gold
+            messages.append(f"You collect {gold} gold.")
+
+        drops = []
+        for item in getattr(enemy, 'loot', []):
+            item.x, item.y = enemy.x, enemy.y
+            drops.append(item)
+
+        # Fallback random drop if no predefined loot
+        if not drops and random.random() < 0.05:
+            loot = self.create_random_item()
+            loot.x, loot.y = enemy.x, enemy.y
+            drops.append(loot)
+
+        return drops

--- a/classes/game.py
+++ b/classes/game.py
@@ -19,6 +19,7 @@ from classes.input_handler import InputHandler
 from classes.renderer import Renderer
 from classes.combat_system import CombatSystem
 from classes.item import Equipment
+from classes.monster_loader import all_monsters
 
 class Game:
     def __init__(self, height, width, stdscr):
@@ -182,14 +183,14 @@ class Game:
             if defender in self.enemies:
                 self.enemies.remove(defender)
 
-                dropped_item = None
+                dropped_items = []
                 if attacker == self.player:
-                    dropped_item = self.combat_system.player_attack_enemy(attacker, defender, self.messages)
+                    dropped_items = self.combat_system.player_attack_enemy(attacker, defender, self.messages)
 
-                if dropped_item:
-                    self.items.append(dropped_item)
+                for item in dropped_items:
+                    self.items.append(item)
                     self.messages.append(
-                        f"{defender.name} dropped a {dropped_item.name}!"
+                        f"{defender.name} dropped a {item.name}!"
                     )
             elif defender == self.player:
                 self.handle_player_death()
@@ -279,36 +280,35 @@ class Game:
         self.spawn_items()
         self.compute_all_shortest_paths()
 
+    def get_monster_template(self):
+        min_cr = max(0.1, (self.dungeon_level - 1) * 0.5)
+        max_cr = self.dungeon_level * 0.5 + 0.5
+        candidates = [m for m in all_monsters if min_cr <= m.challenge_rating <= max_cr]
+        if not candidates:
+            candidates = all_monsters
+        return random.choice(candidates)
+
     def spawn_enemies(self, num_enemies):
         for _ in range(num_enemies):
             pos = self.get_random_floor()
             if not pos:
                 break
             x, y = pos
-            difficulty_factor = min(2, 1 + (self.dungeon_level - 1) * 0.1)
+            template = self.get_monster_template()
+            difficulty_factor = max(1, template.challenge_rating)
             health = int((random.randint(20, 40) + self.dungeon_level * 5) * difficulty_factor)
-            base_damage = 0
-            base_defense = 0
-            enemy = Entity(x, y, 'E', f"Enemy Lv{self.dungeon_level}", health, base_damage, base_defense)
+            enemy = Entity(x, y, 'E', template.name, health, 0, 0)
 
-            # Approximate attributes based on desired difficulty
             raw_damage = int((random.randint(5, 10) + self.dungeon_level) * difficulty_factor)
             raw_defense = int((random.randint(0, 3) + self.dungeon_level // 2) * difficulty_factor)
 
             enemy.strength = raw_damage * 2
             enemy.dexterity = max(1, raw_defense * 3)
             enemy.constitution = max(1, raw_defense * 2)
-            enemy.level = self.dungeon_level
-            if random.random() < 0.3:
-                enemy.add_item(
-                    Item(
-                        "Health Potion",
-                        lambda e: setattr(e, 'health', min(e.max_health, e.health + 20)),
-                        value=20,
-                        weight=1,
-                        effect_type='heal',
-                    )
-                )
+            enemy.level = max(1, round(template.challenge_rating * 2))
+            enemy.xp_reward = template.xp
+            enemy.gold_reward = template.gold
+            enemy.loot = template.create_loot()
             self.enemies.append(enemy)
 
     def get_random_floor(self, max_attempts=1000):

--- a/classes/monster_loader.py
+++ b/classes/monster_loader.py
@@ -1,0 +1,72 @@
+import os
+import json
+import random
+from classes.item import Item, Equipment
+from classes.item_loader import all_items, materials_by_type, all_materials
+
+class MonsterTemplate:
+    def __init__(self, name, xp, gold, items, challenge_rating, archetype):
+        self.name = name
+        self.xp = xp
+        self.gold = gold
+        self.item_names = items
+        self.challenge_rating = challenge_rating
+        self.archetype = archetype
+
+    def create_loot(self):
+        loot = []
+        for item_name in self.item_names:
+            template = next((i for i in all_items if i.name == item_name), None)
+            if template:
+                if isinstance(template, Equipment):
+                    mats = materials_by_type.get(template.material_type, all_materials)
+                    mat = random.choice(mats)
+                    loot_item = Equipment(
+                        f"{mat.name} {template.name}",
+                        template.slot,
+                        template.body_part,
+                        mat.power,
+                        damage=template.damage,
+                        ac=template.ac,
+                        accuracy_bonus=template.accuracy_bonus,
+                        weight=template.weight,
+                        material_type=template.material_type,
+                    )
+                else:
+                    loot_item = Item(
+                        template.name,
+                        template.effect,
+                        duration=getattr(template, 'duration', None),
+                        value=getattr(template, 'value', None),
+                        weight=template.weight,
+                        effect_type=getattr(template, 'effect_type', None),
+                    )
+            else:
+                # Generic placeholder item
+                loot_item = Item(item_name, lambda e: None)
+            loot.append(loot_item)
+        return loot
+
+def load_monsters():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    monsters_dir = os.path.join(script_dir, '..', 'data', 'monsters')
+    templates = []
+    for fname in os.listdir(monsters_dir):
+        if not fname.endswith('.json'):
+            continue
+        with open(os.path.join(monsters_dir, fname), 'r') as f:
+            data = json.load(f)
+        for m in data:
+            templates.append(
+                MonsterTemplate(
+                    m['name'],
+                    m.get('xp', 0),
+                    m.get('gold', 0),
+                    m.get('items', []),
+                    m.get('challenge_rating', 1),
+                    m.get('archetype', 'unknown'),
+                )
+            )
+    return templates
+
+all_monsters = load_monsters()


### PR DESCRIPTION
## Summary
- load monster templates from JSON files
- spawn monsters based on dungeon level and challenge rating
- reward XP and gold from monster data and drop their proper loot
- mention challenge rating based selection in the README

## Testing
- `python -m py_compile classes/monster_loader.py classes/game.py classes/combat_system.py`
- `python - <<'PY'
import random
from classes.game import Game
class DummyScreen:
    def getmaxyx(self):
        return (40,80)
Game(20,40, DummyScreen())
PY`

------
https://chatgpt.com/codex/tasks/task_e_6840876dd350832bbec4b4ee15a3d77e