### PR TITLE
Fix inventory crash on boost items with missing effect_type

### DIFF
--- a/classes/renderer.py
+++ b/classes/renderer.py
@@ -71,8 +71,9 @@ class Renderer:
                 info.append(f"Heal {item.value}")
             elif getattr(item, 'effect_type', None) == 'restore_mana':
                 info.append(f"Mana {item.value}")
-            elif getattr(item, 'effect_type', '').startswith('boost_'):
-                stat = item.effect_type.split('_', 1)[1].title()
+            else_effect = getattr(item, 'effect_type', '') or ''
+            if else_effect.startswith('boost_'):
+                stat = else_effect.split('_', 1)[1].title()
                 info.append(f"+{item.value} {stat}")
             info.append(f"WT {item.weight}")
         return ' '.join(info)


### PR DESCRIPTION
## Summary
- handle items missing an `effect_type` in `Renderer._format_item_stats`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684088b9309c832bb93999969710602a