### PR TITLE
Adjust loot drops and item values

### DIFF
--- a/classes/combat_system.py
+++ b/classes/combat_system.py
@@ -52,8 +52,9 @@ class CombatSystem:
 
         drops = []
         for item in getattr(enemy, 'loot', []):
-            item.x, item.y = enemy.x, enemy.y
-            drops.append(item)
+            if random.random() < 0.05:
+                item.x, item.y = enemy.x, enemy.y
+                drops.append(item)
 
         # Fallback random drop if no predefined loot
         if not drops and random.random() < 0.05:

--- a/classes/entity.py
+++ b/classes/entity.py
@@ -200,6 +200,7 @@ class Entity:
                 accuracy_bonus=dagger_base.accuracy_bonus,
                 weight=dagger_base.weight,
                 material_type=dagger_base.material_type,
+                gold_value=dagger_base.gold_value * bronze.value_multiplier,
             )
             self.equip(dagger, 'a')  # 'a' is the weapon slot
 
@@ -213,6 +214,7 @@ class Entity:
                 ac=robe_base.ac,
                 weight=robe_base.weight,
                 material_type=robe_base.material_type,
+                gold_value=robe_base.gold_value * cloth.value_multiplier,
             )
             self.equip(robe, 'f')  # 'f' is the armor slot
 

--- a/classes/game.py
+++ b/classes/game.py
@@ -115,6 +115,7 @@ class Game:
                 accuracy_bonus=item_template.accuracy_bonus,
                 weight=item_template.weight,
                 material_type=item_template.material_type,
+                gold_value=item_template.gold_value * material.value_multiplier,
             )
         else:
             return Item(
@@ -123,6 +124,7 @@ class Game:
                 value=getattr(item_template, "value", None),
                 weight=item_template.weight,
                 effect_type=getattr(item_template, "effect_type", None),
+                gold_value=item_template.gold_value,
             )
 
     def create_specific_item(self, category):
@@ -154,6 +156,7 @@ class Game:
                 accuracy_bonus=template.accuracy_bonus,
                 weight=template.weight,
                 material_type=template.material_type,
+                gold_value=template.gold_value * material.value_multiplier,
             )
         else:
             return Item(
@@ -162,6 +165,7 @@ class Game:
                 value=getattr(template, "value", None),
                 weight=template.weight,
                 effect_type=getattr(template, "effect_type", None),
+                gold_value=template.gold_value,
             )
 
     def map_current_level(self):

--- a/classes/item.py
+++ b/classes/item.py
@@ -1,11 +1,12 @@
 class Item:
-    def __init__(self, name, effect, duration=None, value=None, weight=1, effect_type=None):
+    def __init__(self, name, effect, duration=None, value=None, weight=1, effect_type=None, gold_value=0):
         self.name = name
         self.effect = effect
         self.duration = duration
         self.value = value
         self.weight = weight
         self.effect_type = effect_type
+        self.gold_value = gold_value
         self.x = None
         self.y = None
         self.quantity = 1
@@ -23,8 +24,8 @@ class Item:
         return hash(self.name)
 
 class Equipment(Item):
-    def __init__(self, name, slot, body_part, stat_boost, damage=None, ac=None, accuracy_bonus=0, weight=1, material_type=None):
-        super().__init__(name, None, None, None, weight)
+    def __init__(self, name, slot, body_part, stat_boost, damage=None, ac=None, accuracy_bonus=0, weight=1, material_type=None, gold_value=0):
+        super().__init__(name, None, None, None, weight, None, gold_value)
         self.slot = slot
         self.body_part = body_part
         self.damage = damage

--- a/classes/item_loader.py
+++ b/classes/item_loader.py
@@ -6,6 +6,8 @@ class Material:
     def __init__(self, name, power):
         self.name = name
         self.power = power
+        # Higher tier materials are worth more
+        self.value_multiplier = power
 
 
 def load_materials():
@@ -47,6 +49,7 @@ def load_items():
             value=item_data.get('value'),
             weight=item_data.get('weight', 1),
             effect_type=item_data.get('effect'),
+            gold_value=item_data.get('gold', 10),
         )
         consumables.append(item)
 
@@ -71,6 +74,7 @@ def load_items():
                 accuracy_bonus=accuracy,
                 weight=item_data.get('weight', 1),
                 material_type=material_type,
+                gold_value=item_data.get('gold', 50),
             )
             equipment.append(item)
 

--- a/classes/monster_loader.py
+++ b/classes/monster_loader.py
@@ -31,6 +31,7 @@ class MonsterTemplate:
                         accuracy_bonus=template.accuracy_bonus,
                         weight=template.weight,
                         material_type=template.material_type,
+                        gold_value=template.gold_value * mat.value_multiplier,
                     )
                 else:
                     loot_item = Item(
@@ -40,6 +41,7 @@ class MonsterTemplate:
                         value=getattr(template, 'value', None),
                         weight=template.weight,
                         effect_type=getattr(template, 'effect_type', None),
+                        gold_value=template.gold_value,
                     )
             else:
                 # Generic placeholder item


### PR DESCRIPTION
## Summary
- add gold value fields to `Item` and `Equipment`
- multiply values by material tier when creating equipment
- add default gold values when loading item data
- drop monster loot only 5% of the time

## Testing
- `python -m py_compile classes/*.py pRoguelike.py`

------
https://chatgpt.com/codex/tasks/task_e_684089fb442c832ba265a32d6f173378