### PR TITLE
Add combat stats breakdown screen with Ctrl+W

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Make sure to run the game in a terminal that supports `curses`.
 - Press `0` to auto-explore the dungeon. Use `w` to walk to the nearest stairs.
 - Open the inventory with `i` and press the shown letter to equip or use an item. Drop items with `d`.
 - View your character sheet with `@`.
+- Press `Ctrl+W` to view a breakdown of your damage and defense.
 - Open the options menu with `=` to adjust auto-walk speed and ESC key delay.
 - Press `?` to view this command list at any time.
 - Press `Q` to quit the game.

--- a/classes/entity.py
+++ b/classes/entity.py
@@ -99,6 +99,37 @@ class Entity:
         )
         return round(total_defense, 1)
 
+    def damage_breakdown(self):
+        """Return a list of (source, value) tuples contributing to damage."""
+        components = [("Base damage", self.base_damage)]
+        weapon = next(
+            (slot["item"] for slot in self.equipment.values() if slot["name"] in ["weapon", "missile weapon"]),
+            None,
+        )
+        if weapon and weapon.damage_bonus:
+            components.append((weapon.name, weapon.damage_bonus))
+
+        strength = self.get_stat("strength")
+        components.append((f"Strength {strength}", strength * 0.5))
+
+        components.append((f"Level {self.level}", self.level * 0.5))
+        return components
+
+    def defense_breakdown(self):
+        """Return a list of (source, value) tuples contributing to defense."""
+        components = [("Base defense", self.base_defense)]
+        for slot in self.equipment.values():
+            item = slot.get("item")
+            if item and item.defense_bonus:
+                components.append((item.name, item.defense_bonus))
+
+        dexterity = self.get_stat("dexterity")
+        constitution = self.get_stat("constitution")
+        components.append((f"Dexterity {dexterity}", dexterity * 0.3))
+        components.append((f"Constitution {constitution}", constitution * 0.2))
+        components.append((f"Level {self.level}", self.level * 0.5))
+        return components
+
     def equip(self, item, slot_key):
         slot = self.equipment[slot_key]
         if isinstance(item, Equipment) and item.slot == slot['name']:

--- a/classes/game.py
+++ b/classes/game.py
@@ -73,9 +73,13 @@ class Game:
         self.walk_speed = 5  # milliseconds between auto-move steps
         self.help_mode = False
         self.speed_input = ""
+        self.combat_stats_mode = False
 
     def open_character_stats_screen(self):
         self.character_stats_mode = True
+
+    def open_combat_stats_screen(self):
+        self.combat_stats_mode = True
 
     def spawn_item_in_inventory(self):
         item = self.create_random_item()

--- a/classes/input_handler.py
+++ b/classes/input_handler.py
@@ -27,6 +27,8 @@ class InputHandler:
             self.handle_character_screen_input(key)
         elif self.game.character_stats_mode:
             self.handle_character_stats_input(key)
+        elif self.game.combat_stats_mode:
+            self.handle_combat_stats_input(key)
         elif key == ord('i'):
             self.game.inventory_mode = True
             self.game.inventory_page = 0
@@ -56,6 +58,10 @@ class InputHandler:
                 return
             else:
                 self.game.walk_mode = False
+
+        if key == 23:  # CTRL+W
+            self.game.open_combat_stats_screen()
+            return
 
         if key == ord('w'):
             if not (self.game.explored[self.game.stairs_y][self.game.stairs_x] or
@@ -176,6 +182,10 @@ class InputHandler:
     def handle_character_stats_input(self, key):
         if key == 27:  # ESC key
             self.game.character_stats_mode = False
+
+    def handle_combat_stats_input(self, key):
+        if key == 27:  # ESC key
+            self.game.combat_stats_mode = False
 
     def handle_backpack_input(self, key):
         if key == 27:  # ESC key

--- a/classes/renderer.py
+++ b/classes/renderer.py
@@ -412,10 +412,35 @@ class Renderer:
             "Character info: @",
             "Auto-explore: 0",
             "Walk to stairs: w",
+            "Combat stats: Ctrl+W",
             "Options menu: =",
             "Quit game: Q",
             "Show this help: ?",
         ]
+
+        for i, line in enumerate(lines):
+            if i >= height:
+                break
+            color = curses.color_pair(7) if i == 0 else curses.color_pair(4)
+            stdscr.addstr(i, 0, line[:width-1], color)
+
+        stdscr.refresh()
+
+    def draw_combat_stats_screen(self, stdscr):
+        stdscr.clear()
+        height, width = stdscr.getmaxyx()
+
+        dmg_lines = ["Combat Stats (press escape to exit):", "", "Damage Breakdown:"]
+        for src, val in self.game.player.damage_breakdown():
+            dmg_lines.append(f"  {src}: {val:.1f}")
+        dmg_lines.append(f"  Total Damage: {self.game.player.damage:.1f}")
+
+        def_lines = ["", "Defense Breakdown:"]
+        for src, val in self.game.player.defense_breakdown():
+            def_lines.append(f"  {src}: {val:.1f}")
+        def_lines.append(f"  Total Defense: {self.game.player.defense:.1f}")
+
+        lines = dmg_lines + def_lines
 
         for i, line in enumerate(lines):
             if i >= height:

--- a/pRoguelike.py
+++ b/pRoguelike.py
@@ -268,6 +268,8 @@ def main(stdscr, char_data):
     while True:
         if game.character_stats_mode:
             game.renderer.draw_character_stats_screen(stdscr)
+        elif game.combat_stats_mode:
+            game.renderer.draw_combat_stats_screen(stdscr)
         elif game.inventory_mode:
             game.renderer.draw_inventory(stdscr)
         elif game.backpack_mode:


### PR DESCRIPTION
## Summary
- implement breakdown functions for damage and defense
- add combat stats screen accessible with `Ctrl+W`
- update input handling and renderer for new screen
- mention new command in help menu and README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840aaf515ac832b8221bc7036e5681f