### PR TITLE
Fix armor None handling

### DIFF
--- a/classes/entity.py
+++ b/classes/entity.py
@@ -103,7 +103,7 @@ class Entity:
     def armor(self):
         """Total damage absorption from equipped armor (AC)."""
         return sum(
-            getattr(slot['item'], 'ac', 0)
+            (getattr(slot['item'], 'ac', 0) or 0)
             for slot in self.equipment.values()
             if slot['item']
         )

--- a/classes/item.py
+++ b/classes/item.py
@@ -30,7 +30,7 @@ class Equipment(Item):
         self.slot = slot
         self.body_part = body_part
         self.damage = damage
-        self.ac = ac
+        self.ac = ac if ac is not None else 0
         self.stat_boost = stat_boost
 
         # Separate bonuses allow items to affect different stats


### PR DESCRIPTION
## Summary
- handle missing AC values in `Equipment` and `Entity.armor`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840baa0a344832bb59b10fef348dad8