### PR TITLE
Add pause before game exit on death

### DIFF
--- a/classes/game.py
+++ b/classes/game.py
@@ -67,6 +67,7 @@ class Game:
         self.selected_slot = None
         self.debug_mode = False
         self.quit = False
+        self.game_over = False
         self.walk_mode = False
         self.auto_explore_mode = False
         self.options_mode = False
@@ -673,15 +674,21 @@ class Game:
         sys.exit()
 
     def wait_for_key(self):
-        # This method should be implemented to wait for a key press
-        # For now, we'll just pass
-        pass
+        if self.stdscr:
+            self.stdscr.nodelay(False)
+            self.stdscr.getch()
+        else:
+            try:
+                input()
+            except EOFError:
+                pass
 
     def handle_player_death(self):
         """Handle player death by setting the quit flag and truncating health."""
         self.player.health = max(0, self.player.health)
-        self.messages.append("Game Over!")
+        self.messages.append("Game Over! Press Enter to exit.")
         self.quit = True
+        self.game_over = True
     
     def previous_level(self):
         self.dungeon_level -= 1

--- a/pRoguelike.py
+++ b/pRoguelike.py
@@ -304,6 +304,14 @@ def main(stdscr, char_data):
         if game.quit:
             break
 
+    if game.game_over:
+        game.renderer.draw(stdscr)
+        stdscr.nodelay(False)
+        while True:
+            key = stdscr.getch()
+            if key in (10, 13):
+                break
+
     return
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure player death waits for Enter before quitting
- support waiting for a key press in the Game class

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840bcfdd174832b8316eb1823c09759